### PR TITLE
Installer that works straight from Github, and an IAM policy snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A picture is worth a thousand words:
  * You can restrict that the EC2 instance is only allowed to download public keys from certain IAM users instead of `*`. This way you can restrict SSH access within your account
  * As soon as the public SSH key is deleted from the IAM user a login is no longer possible
 
-## How to run this showcase
+## How to run this showcase (CloudFormation)
 
 1. Upload your public SSH key to IAM: 
  1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
@@ -25,3 +25,12 @@ A picture is worth a thousand words:
 1. Wait until the stack status is `CREATE_COMPLETE`
 1. Copy the `PublicName` from the stack's outputs
 1. Connect via ssh `ssh $Username@$PublicName` replace `$Username` with your IAM user and `$PublicName` with the stack's output
+
+## How to integrate this system into your environment (non-CloudFormation)
+
+1. Upload your public SSH key to IAM as above
+1. Make sure any instances you want to ssh into contain the correct IAM permissions
+(usually based on IAM Profile, but also possibly based on an IAM user and their credentials).
+Look at the `iam_ssh_policy.json` for an example policy that will permit login.
+1. Make sure those instances automatically run a script similar to `install.sh` (note - that script assumes `git` is installed _and_ instances have access to the Internet; feel free to modify it to instead install from a tarball or using any other mechanism such as Chef or Puppet).
+1. Connect to your instances now using `ssh $Username@$PublicName` with `$Username` being your IAM user, and `$PublicName` being your server's name or IP address.

--- a/iam_ssh_policy.json
+++ b/iam_ssh_policy.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1471562879000",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListUsers"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "Stmt1471562943000",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetSSHPublicKey",
+                "iam:ListSSHPublicKeys"
+            ],
+            "Resource": [
+                "arn:aws:iam::<YOUR_ACCOUNT_ID_HERE>:user/*"
+            ]
+        }
+    ]
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+tmpdir=`mktemp -d`
+
+cd $tmpdir
+
+# yum install -y git # if necessary
+# or download a tarball and decompress it instead
+git clone https://github.com/widdix/aws-ec2-ssh.git
+
+cd $tmpdir/aws-ec2-ssh
+
+cp authorized_keys_command.sh /opt/authorized_keys_command.sh
+cp import_users.sh /opt/import_users.sh
+
+sed -i 's:#AuthorizedKeysCommand none:AuthorizedKeysCommand /opt/authorized_keys_command.sh:g' /etc/ssh/sshd_config
+sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
+
+echo "*/10 * * * * root /opt/import_users.sh" > /etc/cron.d/import_users
+chmod 0644 /etc/cron.d/import_users
+
+/opt/import_users.sh
+
+service sshd restart


### PR DESCRIPTION
Rationale
---------
Not everyone can use CloudFormation, or necessarily would be able to integrate these CloudFormation scripts/examples in with their own CloudFormation setup.

So instead I've created a simple `install.sh` script that will download, configure, and execute these scripts. You could put it in your `user-data` to enable newly-launched systems to authenticate using IAM users, or potentially script it using Puppet or Chef.

Additionally, I created a JSON snippet which contains the minimal required policies to be able to let these scripts to run on one of your instances. Just create this policy script in IAM, and add it to any Role you want to assign to your newly-launched instances.