### PR TITLE
Added new 'one_script_install.sh' for even easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ A picture is worth a thousand words:
 (usually based on IAM Profile, but also possibly based on an IAM user and their credentials).
 Look at the `iam_ssh_policy.json` for an example policy that will permit login.
 1. Make sure those instances automatically run a script similar to `install.sh` (note - that script assumes `git` is installed _and_ instances have access to the Internet; feel free to modify it to instead install from a tarball or using any other mechanism such as Chef or Puppet).
+ 1. Alternatively, you can use the `one_script_install.sh` script to install and configure everything, all in one script, without any need for `git` or `tar`. However, be aware that this script embeds both `import_users.sh` and `authorized_keys_command.sh`, so it may fall behind the latest versions in this repo.
 1. Connect to your instances now using `ssh $Username@$PublicName` with `$Username` being your IAM user, and `$PublicName` being your server's name or IP address.

--- a/one_script_install.sh
+++ b/one_script_install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#cp authorized_keys_command.sh /opt/authorized_keys_command.sh
+cat > /opt/authorized_keys_command.sh  <<'EOF'
+#!/bin/bash -e
+
+if [ -z "$1" ]; then
+  exit 1
+fi
+
+aws iam list-ssh-public-keys --user-name "$1" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
+  aws iam get-ssh-public-key --user-name "$1" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
+done
+EOF
+chmod +x /opt/authorized_keys_command.sh
+
+#cp import_users.sh /opt/import_users.sh
+cat > /opt/import_users.sh <<'EOF'
+#!/bin/bash
+
+aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
+  if id -u "$User" >/dev/null 2>&1; then
+    echo "$User exists"
+  else
+    /usr/sbin/adduser "$User"
+    echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
+  fi
+done
+EOF
+
+chmod +x /opt/import_users.sh
+
+sed -i 's:#AuthorizedKeysCommand none:AuthorizedKeysCommand /opt/authorized_keys_command.sh:g' /etc/ssh/sshd_config
+sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
+
+echo "*/10 * * * * root /opt/import_users.sh" > /etc/cron.d/import_users
+chmod 0644 /etc/cron.d/import_users
+
+/opt/import_users.sh
+
+service sshd restart


### PR DESCRIPTION
I was finding that the previous way was adding a few very dear seconds to my instance boot time, and also I had to run it late in the boot sequence, after the prerequisites were available. So I made this new script that embeds your two scripts in it, and can install everything all at once - and now I run it first thing in the boot sequence, so I can ssh in and observe an instance booting if necessary.

The only thing I'm worried about here is that I embedded your scripts in this one. If the 'real ones' change, we might forget to edit this `one_script_install.sh` and it could fall behind.

So if you're interested in adding this to your project, please feel free - and if not (for fear of maintenance hassles or any other reason), you can just close it and it won't hurt my feelings. I just happened to build this version for me so I thought I'd offer to your users too, and it was super easy to just make the PR for it.
