### PR TITLE
Changing adduser command to useradd (Resolves Issue #10)

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -11,7 +11,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   else
     #sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
     SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
-    /usr/sbin/adduser "$SaveUserName"
+    /usr/sbin/useradd "$SaveUserName"
     echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"
   fi
 done


### PR DESCRIPTION
Changing `adduser` command to `useradd` since `adduser` is interactive on debian-based systems.