### PR TITLE
Optimizing existing user check

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -6,7 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  if ! id -u "$SaveUserName" >/dev/null 2>&1; then
+  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
     # Uncomment the following lines if you need to give all users sudo privileges

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -109,7 +109,7 @@ Resources:
                   SaveUserName=${SaveUserName//"="/".equal."}
                   SaveUserName=${SaveUserName//","/".comma."}
                   SaveUserName=${SaveUserName//"@"/".at."}
-                  if ! id -u "$SaveUserName" >/dev/null 2>&1; then
+                  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
                     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
                     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
                     # Uncomment the following lines if you need to give all users sudo privileges


### PR DESCRIPTION
The complete list of users on a system is stored in the `/etc/passwd` file. It would be best to check for existing users from this file rather than depend on the `id` command.

I'm not saying the usage of the `id` command is incorrect. It's just that I thought this would be a better and a more reliable method than the existing `id` method.