### PR TITLE
Remove logging for automation script

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -6,9 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  if id -u "$SaveUserName" >/dev/null 2>&1; then
-    echo "$SaveUserName exists"
-  else
+  if ! id -u "$SaveUserName" >/dev/null 2>&1; then
     #sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
     SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
     /usr/sbin/adduser "$SaveUserName"


### PR DESCRIPTION
It wouldn't make sense to log `INFO` level logs for `cron`-automated scripts. Since this `cron` runs every 5 minutes, this script alone could generate a huge log file daily. It would be best to disable this.