### PR TITLE
Optimizing existing user check (Follow up from Pull Request #14)

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -6,7 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  if id -u "$SaveUserName" >/dev/null 2>&1; then
+  if grep "$SaveUserName" /etc/passwd > /dev/null; then
     echo "$SaveUserName exists"
   else
     #sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.

--- a/import_users.sh
+++ b/import_users.sh
@@ -6,7 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
+  if ! grep "^$SaveUserName:" /etc/passwd > /dev/null; then
     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
     # Uncomment the following lines if you need to give all users sudo privileges

--- a/import_users.sh
+++ b/import_users.sh
@@ -6,7 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  if ! id -u "$SaveUserName" >/dev/null 2>&1; then
+  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
     # Uncomment the following lines if you need to give all users sudo privileges

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -109,7 +109,7 @@ Resources:
                   SaveUserName=${SaveUserName//"="/".equal."}
                   SaveUserName=${SaveUserName//","/".comma."}
                   SaveUserName=${SaveUserName//"@"/".at."}
-                  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
+                  if ! grep "^$SaveUserName:" /etc/passwd > /dev/null; then
                     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
                     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
                     # Uncomment the following lines if you need to give all users sudo privileges

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -109,7 +109,7 @@ Resources:
                   SaveUserName=${SaveUserName//"="/".equal."}
                   SaveUserName=${SaveUserName//","/".comma."}
                   SaveUserName=${SaveUserName//"@"/".at."}
-                  if ! id -u "$SaveUserName" >/dev/null 2>&1; then
+                  if ! grep "$SaveUserName" /etc/passwd > /dev/null; then
                     # sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
                     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
                     # Uncomment the following lines if you need to give all users sudo privileges


### PR DESCRIPTION
I've added a hack to check the only first column of `/etc/passwd` delimited by `:` for usernames in order to avoid skipping of usernames that are subsets of other usernames or users with same home directories. (Resolves https://github.com/widdix/aws-ec2-ssh/pull/14#issuecomment-277179303)