### PR TITLE
Added optional assignment of sudoers from IAM group

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A picture is worth a thousand words:
 
 * On first start all IAM users are imported and local users are created
  * The import also runs every 10 minutes (via cron - calls import_users.sh)
+ * You can control which users are given sudo access as:
+  * none (default)
+  * all
+  * only those in a specific IAM group.
 * On every SSH login the EC2 instance tries to fetch the public key(s) from IAM using sshd's `AuthorizedKeysCommand`
  * You can restrict that the EC2 instance is only allowed to download public keys from certain IAM users instead of `*`. This way you can restrict SSH access within your account
  * As soon as the public SSH key is deleted from the IAM user a login is no longer possible
@@ -33,6 +37,7 @@ A picture is worth a thousand words:
 (usually based on IAM Profile, but also possibly based on an IAM user and their credentials).
 Look at the `iam_ssh_policy.json` for an example policy that will permit login.
 1. Make sure those instances automatically run a script similar to `install.sh` (note - that script assumes `git` is installed _and_ instances have access to the Internet; feel free to modify it to instead install from a tarball or using any other mechanism such as Chef or Puppet).
+ * If you want to control sudo access, you should modify the value of ‘SudoersGroup’ in import_users.sh
 1. Connect to your instances now using `ssh $Username@$PublicName` with `$Username` being your IAM user, and `$PublicName` being your server's name or IP address.
 
 ## Limitations

--- a/iam_ssh_policy.json
+++ b/iam_ssh_policy.json
@@ -5,7 +5,8 @@
       "Sid": "Stmt1471562879000",
       "Effect": "Allow",
       "Action": [
-        "iam:ListUsers"
+        "iam:ListUsers",
+        "iam:GetGroup"
       ],
       "Resource": [
         "*"

--- a/import_users.sh
+++ b/import_users.sh
@@ -22,13 +22,13 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   if [[ ! -z "${SUDOERS_GROUP}" ]]; then
     UserIsSudoer="";
     for Sudoer in $SUDOERS; do
-      if "$Sudoer" == "$User"; then
+      if [[ "$Sudoer" == "$User" ]]; then
         UserIsSudoer="yes";
       fi
     done
 
     SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
-    if "$UserIsSudoer" == "yes"; then
+    if [[ "$UserIsSudoer" == "yes" ]]; then
       echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"
     else
       [[ ! -f "/etc/sudoers.d/$SaveUserFileName" ]] || rm "/etc/sudoers.d/$SaveUserFileName"

--- a/import_users.sh
+++ b/import_users.sh
@@ -14,16 +14,16 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   SaveUserName=${SaveUserName//"="/".equal."}
   SaveUserName=${SaveUserName//","/".comma."}
   SaveUserName=${SaveUserName//"@"/".at."}
-  # sudo will read each file in /etc/sudoers.d, skipping file names that end in
-  # ‘~’ or contain a ‘.’ character to avoid causing problems with package
-  # manager or editor temporary/backup files.
-  SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
-  SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"
   if ! grep "^$SaveUserName:" /etc/passwd > /dev/null; then
     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName"
   fi
 
   if [[ ! -z "${SudoersGroup}" ]]; then
+    # sudo will read each file in /etc/sudoers.d, skipping file names that end
+    # in ‘~’ or contain a ‘.’ character to avoid causing problems with package
+    # manager or editor temporary/backup files.
+    SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
+    SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"
     if [[ "${SudoersGroup}" == "##ALL##" ]] || echo "$Sudoers" | grep "^$User\$" > /dev/null; then
       echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "$SaveUserSudoFilePath"
     else

--- a/import_users.sh
+++ b/import_users.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Specify an IAM group for users who should be given sudo privileges, or leave
+# empty to give no-one sudo access.
+SUDOERS_GROUP="Bioinformaticians";
+[[ -z "${SUDOERS_GROUP}" ]] || SUDOERS=$(aws iam get-group --group-name "${SUDOERS_GROUP}" --query "Users[].[UserName]" --output text);
+
 aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
   SaveUserName="$User"
   SaveUserName=${SaveUserName//"+"/".plus."}
@@ -12,5 +17,10 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
     # Uncomment the following lines if you need to give all users sudo privileges
     # SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
     # echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"
+
+    for user in $SUDOERS; do
+      SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
+      echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"
+    done
   fi
 done

--- a/import_users.sh
+++ b/import_users.sh
@@ -2,8 +2,8 @@
 
 # Specify an IAM group for users who should be given sudo privileges, or leave
 # empty to give no-one sudo access.
-SUDOERS_GROUP="";
-[[ -z "${SUDOERS_GROUP}" ]] || SUDOERS=$(aws iam get-group --group-name "${SUDOERS_GROUP}" --query "Users[].[UserName]" --output text);
+SudoersGroup="";
+[[ -z "${SudoersGroup}" ]] || Sudoers=$(aws iam get-group --group-name "${SudoersGroup}" --query "Users[].[UserName]" --output text);
 
 aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
   SaveUserName="$User"
@@ -19,9 +19,9 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
     # echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"
   fi
 
-  if [[ ! -z "${SUDOERS_GROUP}" ]]; then
+  if [[ ! -z "${SudoersGroup}" ]]; then
     UserIsSudoer="";
-    for Sudoer in $SUDOERS; do
+    for Sudoer in $Sudoers; do
       if [[ "$Sudoer" == "$User" ]]; then
         UserIsSudoer="yes";
       fi

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,12 @@ cd $tmpdir/aws-ec2-ssh
 cp authorized_keys_command.sh /opt/authorized_keys_command.sh
 cp import_users.sh /opt/import_users.sh
 
+# To control which users are given sudo privileges, uncomment the line below
+# changing GROUPNAME to either the name of the IAM group for sudo users, or
+# to ##ALL## to give all users sudo access. If you leave it blank, no users will
+# be given sudo access.
+#sudo sed -i 's/SudoersGroup=""/SudoersGroup="GROUPNAME"/' /opt/import_users.sh
+
 sed -i 's:#AuthorizedKeysCommand none:AuthorizedKeysCommand /opt/authorized_keys_command.sh:g' /etc/ssh/sshd_config
 sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
 


### PR DESCRIPTION
Hi,

This pull request adds the ability to optionally specify an IAM group for users who should be made sudoers. This means some users can automatically be made sudoers and that the sudoers are managed through IAM.

If the SUDOERS_GROUP is assigned: each time import_users.sh is run, the list of users in that group is retrieved and any users in that group are given sudo access. Users not in that group are removed from sudo access (if they previously had it granted by this script.

The instance profile will additionally require "iam:GetGroup" permission if the SUDOERS_GROUP is assigned.