### PR TITLE
Merge of my AssumeRole branch, and some other forks

### DIFF
--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -7,12 +7,12 @@ fi
 # Assume a role before contacting AWS IAM to get users and keys.
 # This can be used if you define your users in one AWS account, while the EC2
 # instance you use this script runs in another.
-AssumeRole=""
+ASSUMEROLE=""
 
-if [[ ! -z "${AssumeRole}" ]]
+if [[ ! -z "${ASSUMEROLE}" ]]
 then
   STSCredentials=$(aws sts assume-role \
-    --role-arn "${AssumeRole}" \
+    --role-arn "${ASSUMEROLE}" \
     --role-session-name something \
     --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
     --output text)
@@ -30,6 +30,6 @@ SaveUserName=${SaveUserName//"="/".equal."}
 SaveUserName=${SaveUserName//","/".comma."}
 SaveUserName=${SaveUserName//"@"/".at."}
 
-aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
+aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read -r KeyId; do
   aws iam get-ssh-public-key --user-name "$SaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
 done

--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -4,6 +4,26 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+# Assume a role before contacting AWS IAM to get users and keys.
+# This can be used if you define your users in one AWS account, while the EC2
+# instance you use this script runs in another.
+AssumeRole=""
+
+if [[ ! -z "${AssumeRole}" ]]
+then
+  STSCredentials=$(aws sts assume-role \
+    --role-arn "${AssumeRole}" \
+    --role-session-name something \
+    --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
+    --output text)
+
+  AWS_ACCESS_KEY_ID=$(echo "${STSCredentials}" | awk '{print $2}')
+  AWS_SECRET_ACCESS_KEY=$(echo "${STSCredentials}" | awk '{print $3}')
+  AWS_SESSION_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
+  AWS_SECURITY_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
+fi
+
 SaveUserName="$1"
 SaveUserName=${SaveUserName//"+"/".plus."}
 SaveUserName=${SaveUserName//"="/".equal."}

--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -24,12 +24,12 @@ then
   export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 fi
 
-SaveUserName="$1"
-SaveUserName=${SaveUserName//"+"/".plus."}
-SaveUserName=${SaveUserName//"="/".equal."}
-SaveUserName=${SaveUserName//","/".comma."}
-SaveUserName=${SaveUserName//"@"/".at."}
+UnsaveUserName="$1"
+UnsaveUserName=${UnsaveUserName//".plus."/"+"}
+UnsaveUserName=${UnsaveUserName//".equal."/"="}
+UnsaveUserName=${UnsaveUserName//".comma."/","}
+UnsaveUserName=${UnsaveUserName//".at."/"@"}
 
-aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read -r KeyId; do
-  aws iam get-ssh-public-key --user-name "$SaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
+aws iam list-ssh-public-keys --user-name "$UnsaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read -r KeyId; do
+  aws iam get-ssh-public-key --user-name "$UnsaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
 done

--- a/docs/multiawsaccount.md
+++ b/docs/multiawsaccount.md
@@ -1,0 +1,28 @@
+Use multiple AWS accounts
+=========================
+
+If you are using multiple AWS accounts (as you should be, read the best practices)
+you probably have one account with all the IAM users, and are using seperate accounts for
+your environments.
+Support for this is provided using the AssumeRole functionality in AWS.
+
+Setup IAM account with the IAM users
+------------------------------------
+
+ * Create a new role with type 'Role for Cross-Account Access'
+   and select the option 'Provide access between AWS accounts you own'
+ * Put the first 'ec2' account number in 'Account ID' and leave
+   'Require MFA' unchecked
+ * Skip attaching a policy (we will create our own later)
+ * Review the new role and create it
+
+Now we have to provide the correct access to this role.
+You can use the `iam_ssh_policy.json` as provided in the root of this repository
+
+
+Setup IAM account with the ec2 instances
+----------------------------------------
+
+The EC2 role you use for launching the EC2 instances should have the policy
+as listed in `iam_crossaccount_policy.json` file. Replace the account id and role name
+in that file with the account id and role you created in the steps above.

--- a/docs/multiawsaccount.md
+++ b/docs/multiawsaccount.md
@@ -1,13 +1,11 @@
-Use multiple AWS accounts
-=========================
+# Use multiple AWS accounts
 
 If you are using multiple AWS accounts (as you should be, read the best practices)
 you probably have one account with all the IAM users, and are using seperate accounts for
 your environments.
 Support for this is provided using the AssumeRole functionality in AWS.
 
-Setup IAM account with the IAM users
-------------------------------------
+## Setup IAM account with the IAM users
 
  * Create a new role with type 'Role for Cross-Account Access'
    and select the option 'Provide access between AWS accounts you own'
@@ -20,8 +18,7 @@ Now we have to provide the correct access to this role.
 You can use the `iam_ssh_policy.json` as provided in the root of this repository
 
 
-Setup IAM account with the ec2 instances
-----------------------------------------
+## Setup IAM account with the ec2 instances
 
 The EC2 role you use for launching the EC2 instances should have the policy
 as listed in `iam_crossaccount_policy.json` file. Replace the account id and role name

--- a/iam_crossaccount_policy.json
+++ b/iam_crossaccount_policy.json
@@ -1,0 +1,8 @@
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Action": "sts:AssumeRole",
+        "Resource": "arn:aws:iam::<IAM ACCOUNT ID WITH IAM USERS>:role/<ROLE WITH IAM ACCESS>"
+    }
+}

--- a/import_users.sh
+++ b/import_users.sh
@@ -121,7 +121,6 @@ function clean_iam_username() {
     clean_username=${clean_username//"="/".equal."}
     clean_username=${clean_username//","/".comma."}
     clean_username=${clean_username//"@"/".at."}
-    clean_username=${clean_username//"-"/".dash."}
     echo "${clean_username}"
 }
 

--- a/import_users.sh
+++ b/import_users.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Assume a role before contacting AWS IAM to get users and keys.
+# This can be used if you define your users in one AWS account, while the EC2
+# instance you use this script runs in another.
+AssumeRole=""
+
+if [[ ! -z "${AssumeRole}" ]]
+then
+
+    STSCredentials=$(aws sts assume-role \
+        --role-arn "${AssumeRole}" \
+        --role-session-name something \
+        --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
+        --output text)
+
+    AWS_ACCESS_KEY_ID=$(echo "${STSCredentials}" | awk '{print $2}')
+    AWS_SECRET_ACCESS_KEY=$(echo "${STSCredentials}" | awk '{print $3}')
+    AWS_SESSION_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
+    AWS_SECURITY_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
+    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
+fi
+
 # Specify an IAM group for users who should be given sudo privileges, or leave
 # empty to not change sudo access, or give it the value '##ALL##' to have all
 # users be given sudo rights.

--- a/import_users.sh
+++ b/import_users.sh
@@ -2,7 +2,7 @@
 
 # Which IAM groups have access to this instance
 # Comma seperated list of IAM groups. Leave empty for all available IAM users
-IAM_AUTHORIZED_GROUPS="developers-devops-senior,developers-core"
+IAM_AUTHORIZED_GROUPS=""
 
 # Special group to mark users as being synced by our script
 LOCAL_MARKER_GROUP="iam-synced-users"

--- a/import_users.sh
+++ b/import_users.sh
@@ -1,54 +1,98 @@
 #!/bin/bash
 
+# Which IAM groups have access to this instance
+# Comma seperated list of IAM groups. Leave empty for all available IAM users
+IAM_AUTHORIZED_GROUPS="developers-devops-senior,developers-core"
+
+# Special group to mark users as being synced by our script
+LOCAL_MARKER_GROUP="iam-synced-users"
+
+# Give the users these groups
+LOCAL_GROUPS="wheel"
+
 # Assume a role before contacting AWS IAM to get users and keys.
 # This can be used if you define your users in one AWS account, while the EC2
 # instance you use this script runs in another.
-AssumeRole=""
+ASSUMEROLE=""
 
-if [[ ! -z "${AssumeRole}" ]]
-then
+function setup_aws_credentials() {
+    local stscredentials
+    if [[ ! -z "${ASSUMEROLE}" ]]
+    then
+        stscredentials=$(aws sts assume-role \
+            --role-arn "${ASSUMEROLE}" \
+            --role-session-name something \
+            --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
+            --output text)
 
-    STSCredentials=$(aws sts assume-role \
-        --role-arn "${AssumeRole}" \
-        --role-session-name something \
-        --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
-        --output text)
-
-    AWS_ACCESS_KEY_ID=$(echo "${STSCredentials}" | awk '{print $2}')
-    AWS_SECRET_ACCESS_KEY=$(echo "${STSCredentials}" | awk '{print $3}')
-    AWS_SESSION_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
-    AWS_SECURITY_TOKEN=$(echo "${STSCredentials}" | awk '{print $1}')
-    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
-fi
-
-# Specify an IAM group for users who should be given sudo privileges, or leave
-# empty to not change sudo access, or give it the value '##ALL##' to have all
-# users be given sudo rights.
-SudoersGroup=""
-[[ -z "${SudoersGroup}" ]] || [[ "${SudoersGroup}" == "##ALL##" ]] || Sudoers=$(
-  aws iam get-group --group-name "${SudoersGroup}" --query "Users[].[UserName]" --output text
-);
-
-aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
-  SaveUserName="$User"
-  SaveUserName=${SaveUserName//"+"/".plus."}
-  SaveUserName=${SaveUserName//"="/".equal."}
-  SaveUserName=${SaveUserName//","/".comma."}
-  SaveUserName=${SaveUserName//"@"/".at."}
-  if ! grep "^$SaveUserName:" /etc/passwd > /dev/null; then
-    /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName"
-  fi
-
-  if [[ ! -z "${SudoersGroup}" ]]; then
-    # sudo will read each file in /etc/sudoers.d, skipping file names that end
-    # in ‘~’ or contain a ‘.’ character to avoid causing problems with package
-    # manager or editor temporary/backup files.
-    SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
-    SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"
-    if [[ "${SudoersGroup}" == "##ALL##" ]] || echo "$Sudoers" | grep "^$User\$" > /dev/null; then
-      echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "$SaveUserSudoFilePath"
-    else
-      [[ ! -f "$SaveUserSudoFilePath" ]] || rm "$SaveUserSudoFilePath"
+        AWS_ACCESS_KEY_ID=$(echo "${stscredentials}" | awk '{print $2}')
+        AWS_SECRET_ACCESS_KEY=$(echo "${stscredentials}" | awk '{print $3}')
+        AWS_SESSION_TOKEN=$(echo "${stscredentials}" | awk '{print $1}')
+        AWS_SECURITY_TOKEN=$(echo "${stscredentials}" | awk '{print $1}')
+        export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
     fi
-  fi
-done
+}
+
+# Get all IAM users in the specified groups
+function get_iam_users() {
+    local group
+    for group in $(echo ${IAM_AUTHORIZED_GROUPS} | tr "," " "); do
+        aws iam get-group \
+            --group-name "${group}" \
+            --query "Users[].[UserName]" \
+            --output text
+    done
+}
+
+# Create or update a local user based on info from the IAM group
+function create_or_update_local_user() {
+    id "${1}" >/dev/null 2>&1 \
+        || /usr/sbin/useradd --create-home --shell /bin/bash "${1}" \
+        && chown -R "${1}:${1}" "/home/${1}"
+    usermod -G "${LOCAL_GROUPS},${LOCAL_MARKER_GROUP}" "${1}"
+}
+
+function clean_iam_username() {
+    local clean_username="${1}"
+    clean_username=${clean_username//"+"/".plus."}
+    clean_username=${clean_username//"="/".equal."}
+    clean_username=${clean_username//","/".comma."}
+    clean_username=${clean_username//"@"/".at."}
+    echo "${clean_username}"
+}
+
+function sync_accounts() {
+    # Do some basic checks
+    if [ -z "${IAM_AUTHORIZED_GROUPS}" ]
+    then
+        echo "Please specify what IAM groups are authorized on this instance"
+        exit 1
+    fi
+
+    if [ -z "${LOCAL_MARKER_GROUP}" ]
+    then
+        echo "Please specify a local group to mark imported users. eg iam-synced-users"
+        exit 1
+    fi
+
+    # Check if local marker group exists, if not, create it
+    getent group "${LOCAL_MARKER_GROUP}" >/dev/null 2>&1 || groupadd "${LOCAL_MARKER_GROUP}"
+
+    # setup the aws credentials if needed
+    setup_aws_credentials
+
+    # declare and set some variables
+    local iam_users
+    local user
+
+    iam_users=$(get_iam_users)
+    # Add or update the users found in IAM
+    for user in ${iam_users}; do
+        SaveUserName=$(clean_iam_username "${user}")
+        create_or_update_local_user "${SaveUserName}"
+    done
+
+    # Remove users no longer in the IAM group(s)
+}
+
+sync_accounts

--- a/import_users.sh
+++ b/import_users.sh
@@ -106,6 +106,7 @@ function clean_iam_username() {
     clean_username=${clean_username//"="/".equal."}
     clean_username=${clean_username//","/".comma."}
     clean_username=${clean_username//"@"/".at."}
+    clean_username=${clean_username//"-"/".dash."}
     echo "${clean_username}"
 }
 

--- a/import_users.sh
+++ b/import_users.sh
@@ -133,7 +133,7 @@ function sync_accounts() {
     fi
 
     # Check if local marker group exists, if not, create it
-    /usr/bin/getent group "${LOCAL_MARKER_GROUP}" >/dev/null 2>&1 || groupadd "${LOCAL_MARKER_GROUP}"
+    /usr/bin/getent group "${LOCAL_MARKER_GROUP}" >/dev/null 2>&1 || /usr/sbin/groupadd "${LOCAL_MARKER_GROUP}"
 
     # setup the aws credentials if needed
     setup_aws_credentials

--- a/import_users.sh
+++ b/import_users.sh
@@ -8,7 +8,7 @@ IAM_AUTHORIZED_GROUPS=""
 LOCAL_MARKER_GROUP="iam-synced-users"
 
 # Give the users these local UNIX groups
-LOCAL_GROUPS="wheel"
+LOCAL_GROUPS=""
 
 # Specify an IAM group for users who should be given sudo privileges, or leave
 # empty to not change sudo access, or give it the value '##ALL##' to have all
@@ -69,15 +69,22 @@ function create_or_update_local_user() {
     local iamusername
     local username
     local sudousers
+    local localusergroups
 
     iamusername="${1}"
     username="${2}"
     sudousers="${2}"
+    localusergroups="${LOCAL_MARKER_GROUP}"
+
+    if [ ! -z "${LOCAL_GROUPS}" ]
+    then
+        localusergroups="${LOCAL_GROUPS},${LOCAL_MARKER_GROUP}"
+    fi
 
     id "${username}" >/dev/null 2>&1 \
         || /usr/sbin/useradd --create-home --shell /bin/bash "${username}" \
         && chown -R "${username}:${username}" "/home/${username}"
-    usermod -G "${LOCAL_GROUPS},${LOCAL_MARKER_GROUP}" "${username}"
+    usermod -G "${localusergroups}" "${username}"
 
     # Should we add this user to sudo ?
     if [[ ! -z "${SUDOERSGROUP}" ]]

--- a/import_users.sh
+++ b/import_users.sh
@@ -60,7 +60,7 @@ function get_iam_users() {
 
 # Get previously synced users
 function get_local_users() {
-    getent group ${LOCAL_MARKER_GROUP} \
+    /usr/bin/getent group ${LOCAL_MARKER_GROUP} \
         | cut -d : -f4- \
         | sed "s/,/ /g"
 }
@@ -92,7 +92,7 @@ function create_or_update_local_user() {
 
     id "${username}" >/dev/null 2>&1 \
         || /usr/sbin/useradd --create-home --shell /bin/bash "${username}" \
-        && chown -R "${username}:${username}" "/home/${username}"
+        && /bin/chown -R "${username}:${username}" "/home/${username}"
     /usr/sbin/usermod -G "${localusergroups}" "${username}"
 
     # Should we add this user to sudo ?
@@ -110,9 +110,9 @@ function create_or_update_local_user() {
 }
 
 function delete_local_user() {
-    usermod -L -s /sbin/nologin "${1}"
-    pkill -KILL -u "${1}"
-    userdel -r "${1}"
+    /usr/sbin/usermod -L -s /sbin/nologin "${1}"
+    /usr/bin/pkill -KILL -u "${1}"
+    /usr/sbin/userdel -r "${1}"
 }
 
 function clean_iam_username() {
@@ -133,7 +133,7 @@ function sync_accounts() {
     fi
 
     # Check if local marker group exists, if not, create it
-    getent group "${LOCAL_MARKER_GROUP}" >/dev/null 2>&1 || groupadd "${LOCAL_MARKER_GROUP}"
+    /usr/bin/getent group "${LOCAL_MARKER_GROUP}" >/dev/null 2>&1 || groupadd "${LOCAL_MARKER_GROUP}"
 
     # setup the aws credentials if needed
     setup_aws_credentials

--- a/import_users.sh
+++ b/import_users.sh
@@ -45,13 +45,15 @@ function get_iam_users() {
     then
         aws iam list-users \
             --query "Users[].[UserName]" \
-            --output text
+            --output text \
+        | sed "s/\r//g"
     else
         for group in $(echo ${IAM_AUTHORIZED_GROUPS} | tr "," " "); do
             aws iam get-group \
                 --group-name "${group}" \
                 --query "Users[].[UserName]" \
-                --output text
+                --output text \
+            | sed "s/\r//g"
         done
     fi
 }
@@ -144,9 +146,9 @@ function sync_accounts() {
     local removed_users
     local user
 
-    iam_users=$(get_iam_users)
-    sudo_users=$(get_sudoers_users)
-    local_users=$(get_local_users)
+    iam_users=$(get_iam_users | sort | uniq)
+    sudo_users=$(get_sudoers_users | sort | uniq)
+    local_users=$(get_local_users | sort | uniq)
 
     intersection=$(echo ${local_users} ${iam_users} | tr " " "\n" | sort | uniq -D | uniq)
     removed_users=$(echo ${local_users} ${intersection} | tr " " "\n" | sort | uniq -u)

--- a/import_users.sh
+++ b/import_users.sh
@@ -82,7 +82,7 @@ function create_or_update_local_user() {
 
     iamusername="${1}"
     username="${2}"
-    sudousers="${2}"
+    sudousers="${3}"
     localusergroups="${LOCAL_MARKER_GROUP}"
 
     if [ ! -z "${LOCAL_GROUPS}" ]

--- a/import_users.sh
+++ b/import_users.sh
@@ -93,7 +93,7 @@ function create_or_update_local_user() {
     id "${username}" >/dev/null 2>&1 \
         || /usr/sbin/useradd --create-home --shell /bin/bash "${username}" \
         && chown -R "${username}:${username}" "/home/${username}"
-    usermod -G "${localusergroups}" "${username}"
+    /usr/sbin/usermod -G "${localusergroups}" "${username}"
 
     # Should we add this user to sudo ?
     if [[ ! -z "${SUDOERSGROUP}" ]]

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,12 @@ cd "${tmpdir}/aws-ec2-ssh" || exit 1
 cp authorized_keys_command.sh /opt/authorized_keys_command.sh
 cp import_users.sh /opt/import_users.sh
 
+# To control which users are imported/synced, uncomment the line below
+# changing GROUPNAMES to a comma seperated list of IAM groups you want to sync.
+# You can specify 1 or more groups, comma seperated, without spaces.
+# If you leave it blank, all IAM users will be synced.
+#sudo sed -i 's/IAM_AUTHORIZED_GROUPS=""/IAM_AUTHORIZED_GROUPS="GROUPNAMES"/' /opt/import_users.sh
+
 # To control which users are given sudo privileges, uncomment the line below
 # changing GROUPNAME to either the name of the IAM group for sudo users, or
 # to ##ALL## to give all users sudo access. If you leave it blank, no users will

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,11 @@ cp import_users.sh /opt/import_users.sh
 # be given sudo access.
 #sudo sed -i 's/SUDOERSGROUP=""/SUDOERSGROUP="GROUPNAME"/' /opt/import_users.sh
 
+# To control which local groups a user will get, uncomment the line belong
+# changing GROUPNAMES to a comma seperated list of local UNIX groups.
+# If you live it blank, this setting will be ignored
+#sudo sed -i 's/LOCAL_GROUPS=""/LOCAL_GROUPS="GROUPNAMES"/' /opt/import_users.sh
+
 # If your IAM users are in another AWS account, put the AssumeRole ARN here.
 # replace the word ASSUMEROLEARN with the full arn. eg 'arn:aws:iam::$accountid:role/$role'
 # See docs/multiawsaccount.md on how to make this work

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-tmpdir=`mktemp -d`
+tmpdir=$(mktemp -d)
 
-cd $tmpdir
+cd "${tmpdir}" || exit 1
 
 # yum install -y git # if necessary
 # or download a tarball and decompress it instead
 git clone https://github.com/widdix/aws-ec2-ssh.git
 
-cd $tmpdir/aws-ec2-ssh
+cd "${tmpdir}/aws-ec2-ssh" || exit 1
 
 cp authorized_keys_command.sh /opt/authorized_keys_command.sh
 cp import_users.sh /opt/import_users.sh
@@ -17,7 +17,13 @@ cp import_users.sh /opt/import_users.sh
 # changing GROUPNAME to either the name of the IAM group for sudo users, or
 # to ##ALL## to give all users sudo access. If you leave it blank, no users will
 # be given sudo access.
-#sudo sed -i 's/SudoersGroup=""/SudoersGroup="GROUPNAME"/' /opt/import_users.sh
+#sudo sed -i 's/SUDOERSGROUP=""/SUDOERSGROUP="GROUPNAME"/' /opt/import_users.sh
+
+# If your IAM users are in another AWS account, put the AssumeRole ARN here.
+# replace the word ASSUMEROLEARN with the full arn. eg 'arn:aws:iam::$accountid:role/$role'
+# See docs/multiawsaccount.md on how to make this work
+#sudo sed -i 's/ASSUMEROLE=""/ASSUMEROLE="ASSUMEROLEARN"/' /opt/import_users.sh
+#sudo sed -i 's/ASSUMEROLE=""/ASSUMEROLE="ASSUMEROLEARN"/' /opt/authorized_keys_command.sh
 
 sed -i 's:#AuthorizedKeysCommand none:AuthorizedKeysCommand /opt/authorized_keys_command.sh:g' /etc/ssh/sshd_config
 sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -8,6 +8,10 @@ Parameters:
   Subnet:
     Type: 'AWS::EC2::Subnet::Id'
     Description: 'The subnet the EC2 instance is launched into.'
+  AssumeRole:
+    Type: 'String'
+    Description: 'The role to assume to get the IAM users to provision into the instance'
+    Default: ''
 Mappings:
   RegionMap:
     'ap-south-1':
@@ -34,6 +38,9 @@ Mappings:
       AMI: 'ami-de347abe'
     'us-west-2':
       AMI: 'ami-b04e92d0'
+Conditions:
+  UseCrossAccountIAM: !Not [!Equals [!Ref AssumeRole, '']]
+  UseLocalIAM: !Equals [!Ref AssumeRole, '']
 Resources:
   SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -61,19 +68,37 @@ Resources:
             Service: 'ec2.amazonaws.com'
           Action: 'sts:AssumeRole'
       Path: /
-      Policies:
-      - PolicyName: iam
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
+  CrossAccountRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: UseCrossAccountIAM
+    Properties:
+      PolicyName: crossaccountiam
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
           - Effect: Allow
-            Action: 'iam:ListUsers'
-            Resource: '*'
-          - Effect: Allow
-            Action:
-            - 'iam:ListSSHPublicKeys'
-            - 'iam:GetSSHPublicKey'
-            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:user/*'
+            Action: 'sts:AssumeRole'
+            Resource: !Ref AssumeRole
+      Roles:
+        - !Ref Role
+  LocalRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: UseLocalIAM
+    Properties:
+      PolicyName: iam
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: 'iam:ListUsers'
+          Resource: '*'
+        - Effect: Allow
+          Action:
+          - 'iam:ListSSHPublicKeys'
+          - 'iam:GetSSHPublicKey'
+          Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:user/*'
+      Roles:
+        - !Ref Role
   Instance:
     Type: AWS::EC2::Instance
     Metadata:
@@ -81,17 +106,37 @@ Resources:
         config:
           files:
             '/opt/authorized_keys_command.sh':
-              content: |
+              !Sub: |
                 #!/bin/bash -e
                 if [ -z "$1" ]; then
                   exit 1
                 fi
 
+                # Assume a role before contacting AWS IAM to get users and keys.
+                # This can be used if you define your users in one AWS account, while the EC2
+                # instance you use this script runs in another.
+                AssumeRole="${AssumeRole}"
+
+                if [[ ! -z "${!AssumeRole}" ]]
+                then
+                  STSCredentials=$(aws sts assume-role \
+                    --role-arn "${!AssumeRole}" \
+                    --role-session-name something \
+                    --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
+                    --output text)
+
+                  AWS_ACCESS_KEY_ID=$(echo "${!STSCredentials}" | awk '{print $2}')
+                  AWS_SECRET_ACCESS_KEY=$(echo "${!STSCredentials}" | awk '{print $3}')
+                  AWS_SESSION_TOKEN=$(echo "${!STSCredentials}" | awk '{print $1}')
+                  AWS_SECURITY_TOKEN=$(echo "${!STSCredentials}" | awk '{print $1}')
+                  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
+                fi
+
                 SaveUserName="$1"
-                SaveUserName=${SaveUserName//"+"/".plus."}
-                SaveUserName=${SaveUserName//"="/".equal."}
-                SaveUserName=${SaveUserName//","/".comma."}
-                SaveUserName=${SaveUserName//"@"/".at."}
+                SaveUserName=${!SaveUserName//"+"/".plus."}
+                SaveUserName=${!SaveUserName//"="/".equal."}
+                SaveUserName=${!SaveUserName//","/".comma."}
+                SaveUserName=${!SaveUserName//"@"/".at."}
 
                 aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
                   aws iam get-ssh-public-key --user-name "$SaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
@@ -100,34 +145,54 @@ Resources:
               owner: root
               group: root
             '/opt/import_users.sh':
-              content: |
+              !Sub: |
                 #!/bin/bash
+
+                # Assume a role before contacting AWS IAM to get users and keys.
+                # This can be used if you define your users in one AWS account, while the EC2
+                # instance you use this script runs in another.
+                AssumeRole="${AssumeRole}"
+
+                if [[ ! -z "${!AssumeRole}" ]]
+                then
+                  STSCredentials=$(aws sts assume-role \
+                    --role-arn "${!AssumeRole}" \
+                    --role-session-name something \
+                    --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
+                    --output text)
+
+                  AWS_ACCESS_KEY_ID=$(echo "${!STSCredentials}" | awk '{print $2}')
+                  AWS_SECRET_ACCESS_KEY=$(echo "${!STSCredentials}" | awk '{print $3}')
+                  AWS_SESSION_TOKEN=$(echo "${!STSCredentials}" | awk '{print $1}')
+                  AWS_SECURITY_TOKEN=$(echo "${!STSCredentials}" | awk '{print $1}')
+                  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
+                fi
 
                 # Specify an IAM group for users who should be given sudo privileges, or leave
                 # empty to not change sudo access, or give it the value '##ALL##' to have all
                 # users be given sudo rights.
                 SudoersGroup=""
-                [[ -z "${SudoersGroup}" ]] || [[ "${SudoersGroup}" == "##ALL##" ]] || Sudoers=$(
-                  aws iam get-group --group-name "${SudoersGroup}" --query "Users[].[UserName]" --output text
+                [[ -z "${!SudoersGroup}" ]] || [[ "${!SudoersGroup}" == "##ALL##" ]] || Sudoers=$(
+                  aws iam get-group --group-name "${!SudoersGroup}" --query "Users[].[UserName]" --output text
                 );
 
                 aws iam list-users --query "Users[].[UserName]" --output text | while read User; do
                   SaveUserName="$User"
-                  SaveUserName=${SaveUserName//"+"/".plus."}
-                  SaveUserName=${SaveUserName//"="/".equal."}
-                  SaveUserName=${SaveUserName//","/".comma."}
-                  SaveUserName=${SaveUserName//"@"/".at."}
+                  SaveUserName=${!SaveUserName//"+"/".plus."}
+                  SaveUserName=${!SaveUserName//"="/".equal."}
+                  SaveUserName=${!SaveUserName//","/".comma."}
+                  SaveUserName=${!SaveUserName//"@"/".at."}
                   if ! grep "^$SaveUserName:" /etc/passwd > /dev/null; then
                     /usr/sbin/useradd --create-home --shell /bin/bash "$SaveUserName" 
                   fi
 
-                  if [[ ! -z "${SudoersGroup}" ]]; then
+                  if [[ ! -z "${!SudoersGroup}" ]]; then
                     # sudo will read each file in /etc/sudoers.d, skipping file names that end
                     # in ‘~’ or contain a ‘.’ character to avoid causing problems with package
                     # manager or editor temporary/backup files.
                     SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
                     SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"
-                    if [[ "${SudoersGroup}" == "##ALL##" ]] || echo "$Sudoers" | grep "^$User\$" > /dev/null; then
+                    if [[ "${!SudoersGroup}" == "##ALL##" ]] || echo "$Sudoers" | grep "^$User\$" > /dev/null; then
                       echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "$SaveUserSudoFilePath"
                     else
                       [[ ! -f "$SaveUserSudoFilePath" ]] || rm "$SaveUserSudoFilePath"


### PR DESCRIPTION
I took the ideas of some of the other forks, and folded it all in one version.

- Allow specifying an ASSUMEROLE arn to fetch users from another AWS account
- Allow specifying which IAM groups you want to import
- Allow specifying a list of local groups to add the imported users to
- Mark all imported users with a special marker group so in the next run we can delete users no longer in the synced IAM groups (or if the IAM user has been deleted)
- Updated install.sh to take these things into account

Thanks to [usertesting](https://github.com/usertesting/aws-ec2-ssh) for most of the work about specifying the IAM groups to import and their work on deleting obsolete users.