### PR TITLE
Adding iam:GetGroup permission to the Policy

### DIFF
--- a/showcase.yaml
+++ b/showcase.yaml
@@ -70,6 +70,9 @@ Resources:
             Action: 'iam:ListUsers'
             Resource: '*'
           - Effect: Allow
+            Action: 'iam:GetGroup'
+            Resource: '*'
+          - Effect: Allow
             Action:
             - 'iam:ListSSHPublicKeys'
             - 'iam:GetSSHPublicKey'


### PR DESCRIPTION
Without this the users from the Sudoers group can't be retrieved, took a bit of time to figure out.