### PR TITLE
Explicitly associate public DNS name and IP

### DIFF
--- a/showcase.yaml
+++ b/showcase.yaml
@@ -185,14 +185,18 @@ Resources:
       ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
       IamInstanceProfile: !Ref InstanceProfile
       InstanceType: 't2.micro'
-      SecurityGroupIds:
-      - !Ref SecurityGroup
-      SubnetId: !Ref Subnet
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -x
           /opt/aws/bin/cfn-init --verbose --stack=${AWS::StackName} --region=${AWS::Region} --resource=Instance
           /opt/aws/bin/cfn-signal --exit-code=$? --stack=${AWS::StackName} --region=${AWS::Region}  --resource=Instance
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: true
+        DeleteOnTermination: true
+        SubnetId: !Ref Subnet
+        DeviceIndex: 0
+        GroupSet:
+        - !Ref SecurityGroup
       Tags:
       - Key: Name
         Value: 'AWS EC2 SSH access with IAM showcase'


### PR DESCRIPTION
The original template does not work when the subnet does not associate public IP addresses by default.  This PR explicitly associates a public IP.