### PR TITLE
Correct username for iam ssh key

### DIFF
--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -4,12 +4,12 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-SaveUserName="$1"
-SaveUserName=${SaveUserName//"+"/".plus."}
-SaveUserName=${SaveUserName//"="/".equal."}
-SaveUserName=${SaveUserName//","/".comma."}
-SaveUserName=${SaveUserName//"@"/".at."}
+UnsaveUserName="$1"
+UnsaveUserName=${UnsaveUserName//".plus."/"+"}
+UnsaveUserName=${UnsaveUserName//".equal."/"="}
+UnsaveUserName=${UnsaveUserName//".comma."/","}
+UnsaveUserName=${UnsaveUserName//".at."/"@"}
 
-aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
-  aws iam get-ssh-public-key --user-name "$SaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
+aws iam list-ssh-public-keys --user-name "$UnsaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
+  aws iam get-ssh-public-key --user-name "$UnsaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
 done


### PR DESCRIPTION
During importing users, we replace some special characters so the resulting username is compatible with linux usernames.

When checking their ssh key, we should undo those changes.

Fixes #27 