### PR TITLE
Limit usernames to 32 chars per `man useradd`

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -121,7 +121,7 @@ function clean_iam_username() {
     clean_username=${clean_username//"="/".equal."}
     clean_username=${clean_username//","/".comma."}
     clean_username=${clean_username//"@"/".at."}
-    echo "${clean_username}"
+    echo "${clean_username:0:32}"
 }
 
 function sync_accounts() {


### PR DESCRIPTION
Hit this limit when CFN created users were pulled by import_users.sh (> 32 characters long).

Sorry for the kick patch, but this gets beyond the error. When `useradd` is called with a username > 32 characters, it returns an error code and message saying "invalid username" or similar. This was blocking other users under the 32 character limit from creating. FWIW, I don't need the script to work with these users, simply don't want it to fail completely.