### PR TITLE
Deprecate SUDOERSGROUP in favor of SUDOERS_GROUPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ one or more of the following lines:
 ```
 ASSUMEROLE="IAM-role-arn"                      # IAM Role ARN for multi account. See below for more info
 IAM_AUTHORIZED_GROUPS="GROUPNAMES"             # Comma seperated list of IAM groups to import
-SUDOERSGROUP="GROUPNAME"                       # IAM group that should have sudo access
+SUDOERS_GROUPS="GROUPNAMES"                    # Comma seperated list of IAM groups that should have sudo access
+SUDOERSGROUP="GROUPNAME"                       # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
 LOCAL_MARKER_GROUP="iam-synced-users"          # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
 LOCAL_GROUPS="GROUPNAMES"                      # Comma seperated list of UNIX groups to add the users in
 USERADD_PROGRAM="/usr/sbin/useradd"            # The useradd program to use. defaults to `/usr/sbin/useradd`

--- a/aws-ec2-ssh.conf
+++ b/aws-ec2-ssh.conf
@@ -1,7 +1,7 @@
 IAM_AUTHORIZED_GROUPS=""
 LOCAL_MARKER_GROUP="iam-synced-users"
 LOCAL_GROUPS=""
-SUDOERSGROUP=""
+SUDOERS_GROUPS=""
 ASSUMEROLE=""
 
 # Remove or set to 0 if you are done with configuration

--- a/import_users.sh
+++ b/import_users.sh
@@ -148,7 +148,7 @@ function create_or_update_local_user() {
     /usr/sbin/usermod -a -G "${localusergroups}" "${username}"
 
     # Should we add this user to sudo ?
-    if [[ ! -z "${SUDOERSG_ROUPS}" ]]
+    if [[ ! -z "${SUDOERS_GROUPS}" ]]
     then
         SaveUserFileName=$(echo "${username}" | tr "." " ")
         SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"

--- a/import_users.sh
+++ b/import_users.sh
@@ -105,7 +105,7 @@ function get_sudoers_users() {
     [[ -z "${SUDOERS_GROUPS}" ]] || [[ "${SUDOERS_GROUPS}" == "##ALL##" ]] ||
         for group in $(echo "${SUDOERS_GROUPS}" | tr "," " "); do
             aws iam get-group \
-                --group-name "${SUDOERS_GROUPS}" \
+                --group-name "${group}" \
                 --query "Users[].[UserName]" \
                 --output text
         done

--- a/install.sh
+++ b/install.sh
@@ -15,9 +15,10 @@ Install import_users.sh and authorized_key_commands.
                        Comma seperated list of IAM groups. Leave empty for all available IAM users
     -l group,group     Give the users these local UNIX groups
                        Comma seperated list
-    -s group           Specify an IAM group for users who should be given sudo privileges, or leave
+    -s group,group     Specify IAM group(s) for users who should be given sudo privileges, or leave
                        empty to not change sudo access, or give it the value '##ALL##' to have all
                        users be given sudo rights.
+                       Comma seperated list
     -p program         Specify your useradd program to use.
                        Defaults to '/usr/sbin/useradd'
     -u "useradd args"  Specify arguments to use with useradd.
@@ -28,7 +29,7 @@ EOF
 }
 
 IAM_GROUPS=""
-SUDO_GROUP=""
+SUDO_GROUPS=""
 LOCAL_GROUPS=""
 ASSUME_ROLE=""
 USERADD_PROGRAM=""
@@ -45,7 +46,7 @@ do
             IAM_GROUPS="$OPTARG"
             ;;
         s)
-            SUDO_GROUP="$OPTARG"
+            SUDO_GROUPS="$OPTARG"
             ;;
         l)
             LOCAL_GROUPS="$OPTARG"
@@ -85,35 +86,21 @@ cd "$tmpdir/aws-ec2-ssh"
 cp authorized_keys_command.sh /opt/authorized_keys_command.sh
 cp import_users.sh /opt/import_users.sh
 
-# To control which users are imported/synced, uncomment the line below
-# changing GROUPNAMES to a comma seperated list of IAM groups you want to sync.
-# You can specify 1 or more groups, comma seperated, without spaces.
-# If you leave it blank, all IAM users will be synced.
 if [ "${IAM_GROUPS}" != "" ]
 then
     echo "IAM_AUTHORIZED_GROUPS=\"${IAM_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
 fi
 
-# To control which users are given sudo privileges, uncomment the line below
-# changing GROUPNAME to either the name of the IAM group for sudo users, or
-# to ##ALL## to give all users sudo access. If you leave it blank, no users will
-# be given sudo access.
-if [ "${SUDO_GROUP}" != "" ]
+if [ "${SUDO_GROUPS}" != "" ]
 then
-    echo "SUDOERSGROUP=\"${SUDO_GROUP}\"" >> /etc/aws-ec2-ssh.conf
+    echo "SUDOERS_GROUPS=\"${SUDO_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
 fi
 
-# To control which local groups a user will get, uncomment the line belong
-# changing GROUPNAMES to a comma seperated list of local UNIX groups.
-# If you live it blank, this setting will be ignored
 if [ "${LOCAL_GROUPS}" != "" ]
 then
     echo "LOCAL_GROUPS=\"${LOCAL_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
 fi
 
-# If your IAM users are in another AWS account, put the AssumeRole ARN here.
-# replace the word ASSUMEROLEARN with the full arn. eg 'arn:aws:iam::$accountid:role/$role'
-# See docs/multiawsaccount.md on how to make this work
 if [ "${ASSUME_ROLE}" != "" ]
 then
     echo "ASSUMEROLE=\"${ASSUME_ROLE}\"" >> /etc/aws-ec2-ssh.conf

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -138,16 +138,17 @@ Resources:
                                     Comma seperated list of IAM groups. Leave empty for all available IAM users
                     -l group,group  Give the users these local UNIX groups
                                     Comma seperated list
-                    -s group        Specify an IAM group for users who should be given sudo privileges, or leave
+                    -s group,group  Specify IAM group(s) for users who should be given sudo privileges, or leave
                                     empty to not change sudo access, or give it the value '##ALL##' to have all
                                     users be given sudo rights.
+                                    Comma seperated list
 
 
                 EOF
                 }
 
                 IAM_GROUPS=""
-                SUDO_GROUP=""
+                SUDO_GROUPS=""
                 LOCAL_GROUPS=""
                 ASSUME_ROLE=""
 
@@ -162,7 +163,7 @@ Resources:
                             IAM_GROUPS="$OPTARG"
                             ;;
                         s)
-                            SUDO_GROUP="$OPTARG"
+                            SUDO_GROUPS="$OPTARG"
                             ;;
                         l)
                             LOCAL_GROUPS="$OPTARG"
@@ -196,35 +197,21 @@ Resources:
                 cp authorized_keys_command.sh /opt/authorized_keys_command.sh
                 cp import_users.sh /opt/import_users.sh
 
-                # To control which users are imported/synced, uncomment the line below
-                # changing GROUPNAMES to a comma seperated list of IAM groups you want to sync.
-                # You can specify 1 or more groups, comma seperated, without spaces.
-                # If you leave it blank, all IAM users will be synced.
                 if [ "${IAM_GROUPS}" != "" ]
                 then
                     echo "IAM_AUTHORIZED_GROUPS=\"${IAM_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
                 fi
 
-                # To control which users are given sudo privileges, uncomment the line below
-                # changing GROUPNAME to either the name of the IAM group for sudo users, or
-                # to ##ALL## to give all users sudo access. If you leave it blank, no users will
-                # be given sudo access.
-                if [ "${SUDO_GROUP}" != "" ]
+                if [ "${SUDO_GROUPS}" != "" ]
                 then
-                    echo "SUDOERSGROUP=\"${SUDO_GROUP}\"" >> /etc/aws-ec2-ssh.conf
+                    echo "SUDOERS_GROUPS=\"${SUDO_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
                 fi
 
-                # To control which local groups a user will get, uncomment the line belong
-                # changing GROUPNAMES to a comma seperated list of local UNIX groups.
-                # If you live it blank, this setting will be ignored
                 if [ "${LOCAL_GROUPS}" != "" ]
                 then
                     echo "LOCAL_GROUPS=\"${LOCAL_GROUPS}\"" >> /etc/aws-ec2-ssh.conf
                 fi
 
-                # If your IAM users are in another AWS account, put the AssumeRole ARN here.
-                # replace the word ASSUMEROLEARN with the full arn. eg 'arn:aws:iam::$accountid:role/$role'
-                # See docs/multiawsaccount.md on how to make this work
                 if [ "${ASSUME_ROLE}" != "" ]
                 then
                     echo "ASSUMEROLE=\"${ASSUME_ROLE}\"" >> /etc/aws-ec2-ssh.conf


### PR DESCRIPTION
The new SUDOERS_GROUPS can now hold a comma seperated list of IAM groups.

Fixes #59 