### PR TITLE
Add support for EC2 Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ A picture is worth a thousand words:
 
 ## How to integrate this system into your environment
 
+### Install via RPM
+
+> Check the [releases](https://github.com/widdix/aws-ec2-ssh/releases) and replace `1.1.0` with the latest released version.
+
+1. Upload your public SSH key to IAM: 
+   1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
+   2. Click the row with your user
+   3. Select the **Security Credentials** tab
+   4. Click the **Upload SSH public key** button at the bottom of the page
+   5. Paste your public SSH key into the text-area and click the **Upload SSH public key** button to save
+2. Attach the IAM permissions defined in `iam_ssh_policy.json` to the EC2 instances (by creating an IAM role and an Instance Profile)
+3. Install the RPM: `rpm -i https://s3-eu-west-1.amazonaws.com/widdix-aws-ec2-ssh-releases-eu-west-1/aws-ec2-ssh-1.1.0-1.el7.centos.noarch.rpm`
+4. The configuration file is placed into `/etc/aws-ec2-ssh.conf`
+5. The RPM creates a crontab file to run import_users.sh every 10 minutes. This file is placed in `/etc/cron.d/import_users`
+
 ### Install via install.sh script
 
 1. Upload your public SSH key to IAM: 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ one or more of the following lines:
 
 ```
 ASSUMEROLE="IAM-role-arn"                      # IAM Role ARN for multi account. See below for more info
-IAM_AUTHORIZED_GROUPS="GROUPNAMES"             # Comma seperated list of IAM groups to import
+IAM_AUTHORIZED_GROUPS="GROUPNAMES"             # Comma separated list of IAM groups to import
 SUDOERS_GROUPS="GROUPNAMES"                    # Comma seperated list of IAM groups that should have sudo access
-IAM_AUTHORIZED_GROUPS_TAG="KeyTag"             # Key Tag of EC2 that contains a Comma seperated list of IAM groups to import
-SUDOERS_GROUPS_TAG="KeyTag"                    # Key Tag of EC2 that contains a Comma seperated list of IAM groups that should have sudo access
+IAM_AUTHORIZED_GROUPS_TAG="KeyTag"             # Key Tag of EC2 that contains a Comma separated list of IAM groups to import - IAM_AUTHORIZED_GROUPS_TAG will override IAM_AUTHORIZED_GROUPS, you can use only one of them 
+SUDOERS_GROUPS_TAG="KeyTag"                    # Key Tag of EC2 that contains a Comma separated list of IAM groups that should have sudo access - SUDOERS_GROUPS_TAG will override SUDOERS_GROUPS, you can use only one of them
 SUDOERSGROUP="GROUPNAME"                       # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
 LOCAL_MARKER_GROUP="iam-synced-users"          # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
 LOCAL_GROUPS="GROUPNAMES"                      # Comma seperated list of UNIX groups to add the users in

--- a/README.md
+++ b/README.md
@@ -37,21 +37,6 @@ A picture is worth a thousand words:
 
 ## How to integrate this system into your environment
 
-### Install via RPM
-
-> Check the [releases](https://github.com/widdix/aws-ec2-ssh/releases) and replace `1.1.0` with the latest released version.
-
-1. Upload your public SSH key to IAM: 
-   1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
-   2. Click the row with your user
-   3. Select the **Security Credentials** tab
-   4. Click the **Upload SSH public key** button at the bottom of the page
-   5. Paste your public SSH key into the text-area and click the **Upload SSH public key** button to save
-2. Attach the IAM permissions defined in `iam_ssh_policy.json` to the EC2 instances (by creating an IAM role and an Instance Profile)
-3. Install the RPM: `rpm -i https://s3-eu-west-1.amazonaws.com/widdix-aws-ec2-ssh-releases-eu-west-1/aws-ec2-ssh-1.1.0-1.el7.centos.noarch.rpm`
-4. The configuration file is placed into `/etc/aws-ec2-ssh.conf`
-5. The RPM creates a crontab file to run import_users.sh every 10 minutes. This file is placed in `/etc/cron.d/import_users`
-
 ### Install via install.sh script
 
 1. Upload your public SSH key to IAM: 
@@ -62,7 +47,8 @@ A picture is worth a thousand words:
    5. Paste your public SSH key into the text-area and click the **Upload SSH public key** button to save
 2. Attach the IAM permissions defined in `iam_ssh_policy.json` to the EC2 instances (by creating an IAM role and an Instance Profile)
 3. Run the `install.sh` script as `root` on the EC2 instances. Run `install.sh -h` for help.
-4. Connect to your EC2 instances now using `ssh $Username@$PublicName` with `$Username` being your IAM user, and `$PublicName` being your server's name or IP address
+4. The configuration file is placed into `/etc/aws-ec2-ssh.conf`
+5. Connect to your EC2 instances now using `ssh $Username@$PublicName` with `$Username` being your IAM user, and `$PublicName` being your server's name or IP address
 
 ## IAM user names and Linux user names
 
@@ -94,6 +80,8 @@ one or more of the following lines:
 ASSUMEROLE="IAM-role-arn"                      # IAM Role ARN for multi account. See below for more info
 IAM_AUTHORIZED_GROUPS="GROUPNAMES"             # Comma seperated list of IAM groups to import
 SUDOERS_GROUPS="GROUPNAMES"                    # Comma seperated list of IAM groups that should have sudo access
+IAM_AUTHORIZED_GROUPS_TAG="KeyTag"             # Key Tag of EC2 that contains a Comma seperated list of IAM groups to import
+SUDOERS_GROUPS_TAG="KeyTag"                    # Key Tag of EC2 that contains a Comma seperated list of IAM groups that should have sudo access
 SUDOERSGROUP="GROUPNAME"                       # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
 LOCAL_MARKER_GROUP="iam-synced-users"          # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
 LOCAL_GROUPS="GROUPNAMES"                      # Comma seperated list of UNIX groups to add the users in

--- a/iam_ssh_policy.json
+++ b/iam_ssh_policy.json
@@ -22,6 +22,16 @@
       "Resource": [
         "arn:aws:iam::<YOUR_USERS_ACCOUNT_ID_HERE>:user/*"
       ]
+    },
+    {
+        "Sid": "Stmt1500475854000",
+        "Effect": "Allow",
+        "Action": [
+            "ec2:DescribeTags"
+        ],
+        "Resource": [
+            "*"
+        ]
     }
   ]
 }


### PR DESCRIPTION
These changes add support for EC2 Tags.
The authorised groups are retrieved by a request to a specified key, saved on IAM_AUTHORIZED_GROUPS_TAG.
In this way, the befitting groups can be set from EC2 console/API, without edit the configuration in local instance.  