### PR TITLE
Removing requirement for git to be installed.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,9 +84,12 @@ tmpdir=$(mktemp -d)
 
 cd "$tmpdir"
 
-git clone -b master https://github.com/widdix/aws-ec2-ssh.git
+GITHUB_VERSION=${GITHUB_VERSION:-master}
+wget https://github.com/widdix/aws-ec2-ssh/archive/${GITHUB_VERSION}.zip
+unzip ${GITHUB_VERSION}.zip
+rm -f ${GITHUB_VERSION}.zip
 
-cd "$tmpdir/aws-ec2-ssh"
+cd "$tmpdir/aws-ec2-ssh-${GITHUB_VERSION}"
 
 cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
 cp import_users.sh $IMPORT_USERS_SCRIPT_FILE

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,10 @@ tmpdir=$(mktemp -d)
 
 cd "$tmpdir"
 
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+./awscli-bundle/install -b ~/bin/aws
+
 GITHUB_VERSION=${GITHUB_VERSION:-master}
 curl -L https://github.com/widdix/aws-ec2-ssh/archive/${GITHUB_VERSION}.tar.gz | tar -xzf -
 

--- a/install.sh
+++ b/install.sh
@@ -85,9 +85,7 @@ tmpdir=$(mktemp -d)
 cd "$tmpdir"
 
 GITHUB_VERSION=${GITHUB_VERSION:-master}
-wget https://github.com/widdix/aws-ec2-ssh/archive/${GITHUB_VERSION}.zip
-unzip ${GITHUB_VERSION}.zip
-rm -f ${GITHUB_VERSION}.zip
+curl -L https://github.com/widdix/aws-ec2-ssh/archive/${GITHUB_VERSION}.tar.gz | tar -xzf -
 
 cd "$tmpdir/aws-ec2-ssh-${GITHUB_VERSION}"
 


### PR DESCRIPTION
The previous version required git to be installed on the destination server but it was only being used for the checkout. It seems more likely that curl/tar would be installed on the destination server than git. I also added the ability to specify a branch/commit to install (defaults to master).