### PR TITLE
Changes to make the code more consistent between AmazonLinux and Ubuntu

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+Operating System: (enter value here)
+AWS CLI Version: (exec `aws --version` and enter value here)
+
+(describe your issue here)

--- a/DEV.md
+++ b/DEV.md
@@ -17,5 +17,5 @@ $ for region in $regions; do ami=$(aws --region $region ec2 describe-images --fi
 ### RegionMapUbuntu
 
 ```
-$ for region in $regions; do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+$ for region in $regions; do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171208" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/import_users.sh
+++ b/import_users.sh
@@ -42,7 +42,7 @@ fi
 : ${USERADD_PROGRAM:="/usr/sbin/useradd"}
 
 # Possibility to provide custom useradd arguments
-: ${USERADD_ARGS:="--create-home --shell /bin/bash"}
+: ${USERADD_ARGS:="--user-group --create-home --shell /bin/bash"}
 
 # Initizalize INSTANCE variable
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/import_users.sh
+++ b/import_users.sh
@@ -56,15 +56,17 @@ function setup_aws_credentials() {
     local stscredentials
     if [[ ! -z "${ASSUMEROLE}" ]]
     then
-        stscredentials=($(aws sts assume-role \
+        stscredentials=$(aws sts assume-role \
             --role-arn "${ASSUMEROLE}" \
             --role-session-name something \
             --query '[Credentials.SessionToken,Credentials.AccessKeyId,Credentials.SecretAccessKey]' \
-            --output text))
+            --output text)
 
-        export AWS_ACCESS_KEY_ID=${stscredentials[0]} 
-        export AWS_SECRET_ACCESS_KEY=${stscredentials[1]} 
-        export AWS_SESSION_TOKEN=${stscredentials[2]}
+        AWS_ACCESS_KEY_ID=$(echo "${stscredentials}" | awk '{print $2}')
+        AWS_SECRET_ACCESS_KEY=$(echo "${stscredentials}" | awk '{print $3}')
+        AWS_SESSION_TOKEN=$(echo "${stscredentials}" | awk '{print $1}')
+        AWS_SECURITY_TOKEN=$(echo "${stscredentials}" | awk '{print $1}')
+        export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+PATH=${PATH}:/usr/local/bin
+
 show_help() {
 cat << EOF
 Usage: ${0##*/} [-hv] [-a ARN] [-i GROUP,GROUP,...] [-l GROUP,GROUP,...] [-s GROUP] [-p PROGRAM] [-u "ARGUMENTS"]
@@ -84,8 +86,7 @@ tmpdir=$(mktemp -d)
 cd "$tmpdir"
 
 AWSCLI_GITHUB_VERSION=${AWSCLI_GITHUB_VERSION:-develop}
-curl -L https://github.com/aws/aws-cli/archive/develop.tar.gz | tar -xzf -
-easy_install "./aws-cli-${AWSCLI_GITHUB_VERSION}/"
+easy_install https://github.com/aws/aws-cli/archive/${AWSCLI_GITHUB_VERSION}.tar.gz
 
 EC2SSH_GITHUB_VERSION=${EC2SSH_GITHUB_VERSION:-master}
 curl -L https://github.com/widdix/aws-ec2-ssh/archive/${EC2SSH_GITHUB_VERSION}.tar.gz | tar -xzf -

--- a/install.sh
+++ b/install.sh
@@ -81,15 +81,16 @@ do
 done
 
 tmpdir=$(mktemp -d)
-
 cd "$tmpdir"
 
-git clone -b master https://github.com/widdix/aws-ec2-ssh.git
+AWSCLI_GITHUB_VERSION=${AWSCLI_GITHUB_VERSION:-develop}
+curl -L https://github.com/aws/aws-cli/archive/develop.tar.gz | tar -xzf -
+easy_install "./aws-cli-${AWSCLI_GITHUB_VERSION}/"
 
-cd "$tmpdir/aws-ec2-ssh"
-
-cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
-cp import_users.sh $IMPORT_USERS_SCRIPT_FILE
+EC2SSH_GITHUB_VERSION=${EC2SSH_GITHUB_VERSION:-master}
+curl -L https://github.com/widdix/aws-ec2-ssh/archive/${EC2SSH_GITHUB_VERSION}.tar.gz | tar -xzf -
+cp "./aws-ec2-ssh-${EC2SSH_GITHUB_VERSION}/authorized_keys_command.sh" $AUTHORIZED_KEYS_COMMAND_FILE
+cp "./aws-ec2-ssh-${EC2SSH_GITHUB_VERSION}/import_users.sh" $IMPORT_USERS_SCRIPT_FILE
 
 if [ "${IAM_GROUPS}" != "" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -126,13 +126,17 @@ fi
 if grep -q '#AuthorizedKeysCommand none' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    if ! grep -q "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 if grep -q '#AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    if ! grep -q 'AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 cat > /etc/cron.d/import_users << EOF
@@ -146,8 +150,53 @@ chmod 0644 /etc/cron.d/import_users
 
 $IMPORT_USERS_SCRIPT_FILE
 
-if [ -f "/etc/init.d/sshd" ]; then
-  service sshd restart
+# In order to support SELinux in Enforcing mode, we need to tell SELinux that it
+# should have the nis_enabled boolean turned on (so it should expect login services
+# like PAM and sshd to make calls to get public keys from a remote server)
+#
+# This is observed on CentOS 7 and RHEL 7
+
+# Capture the return code and use that to determine if we have the command available
+retval=0
+which getenforce > /dev/null 2>&1 || retval=$?
+
+if [[ "$retval" -eq "0" ]]; then
+  retval=0
+  selinuxenabled || retval=$?
+  if [[ "$retval" -eq "0" ]]; then
+    setsebool -P nis_enabled on
+  fi
+fi
+
+
+# Restart sshd using an appropriate method based on the currently running init daemon
+# Note that systemd can return "running" or "degraded" (If a systemd unit has failed)
+# This was observed on the RHEL 7.3 AMI, so it's added for completeness
+# systemd is also not standardized in the name of the ssh service, nor in the places
+# where the unit files are stored.
+
+# Capture the return code and use that to determine if we have the command available
+retval=0
+which systemctl > /dev/null 2>&1 || retval=$?
+
+if [[ "$retval" -eq "0" ]]; then
+  if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then
+    if [ -f "/usr/lib/systemd/system/sshd.service" ] || [ -f "/lib/systemd/system/sshd.service" ]; then
+      systemctl restart sshd.service
+    else
+      systemctl restart ssh.service
+    fi
+  fi
+elif [[ `/sbin/init --version` =~ upstart ]]; then
+    if [ -f "/etc/init.d/sshd" ]; then
+      service sshd restart
+    else
+      service ssh restart
+    fi
 else
-  service ssh restart
+  if [ -f "/etc/init.d/sshd" ]; then
+    /etc/init.d/sshd restart
+  else
+    /etc/init.d/ssh restart
+  fi
 fi

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -23,6 +23,10 @@ Parameters:
     AllowedValues:
     - AmazonLinux
     - Ubuntu
+  EcsSshVersion:
+    Type: String
+    Default: master
+    Description: The github version of the ec2 ssh config scripts to use
 Mappings:
   OSMap:
     AmazonLinux:
@@ -90,7 +94,6 @@ Mappings:
 Conditions:
   UseCrossAccountIAM: !Not [!Equals [!Ref AssumeRole, '']]
   UseLocalIAM: !Equals [!Ref AssumeRole, '']
-  UseUbuntu: !Equals [!Ref OS, 'Ubuntu']
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
 Resources:
   SecurityGroup:
@@ -160,45 +163,35 @@ Resources:
     Metadata:
       'AWS::CloudFormation::Init':
         config:
-          packages: !If
-          - UseUbuntu
-          - apt:
-              git: []
-              awscli: []
-          - yum:
-              git: []
           files:
-            '/opt/install.sh':
-              source: 'https://raw.githubusercontent.com/widdix/aws-ec2-ssh/master/install.sh'
+            /opt/install.sh:
               mode: '000755'
               owner: root
               group: root
+              source: !Sub https://raw.githubusercontent.com/ebmeierj/aws-ec2-ssh/${EcsSshVersion}/install.sh
           commands:
-            a_install:
-              command: !Sub './install.sh -a "${AssumeRole}"'
-              cwd: '/opt'
+            01_install_ec2_ssh:
+              command: !Sub EC2SSH_GITHUB_VERSION=${EcsSshVersion} ./install.sh -a "${AssumeRole}"
+              cwd: /opt
     Properties:
       ImageId: !FindInMap [!FindInMap [OSMap, !Ref OS, RegionMap], !Ref 'AWS::Region', AMI]
       IamInstanceProfile: !Ref InstanceProfile
       InstanceType: 't2.micro'
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
-      UserData: !If
-      - UseUbuntu
-      - 'Fn::Base64': !Sub |
-          #!/bin/bash -x
-          bash -ex << "TRY"
-            apt-get update
-            apt-get -y install python-setuptools
-            mkdir aws-cfn-bootstrap-latest
-            curl -s -m 60 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar xz -C aws-cfn-bootstrap-latest --strip-components 1
-            easy_install aws-cfn-bootstrap-latest
-            /usr/local/bin/cfn-init --verbose --stack=${AWS::StackName} --region=${AWS::Region} --resource=Instance
-          TRY
-          /usr/local/bin/cfn-signal --exit-code $? --stack=${AWS::StackName} --region=${AWS::Region} --resource=Instance
-      - 'Fn::Base64': !Sub |
-          #!/bin/bash -x
-          /opt/aws/bin/cfn-init --verbose --stack=${AWS::StackName} --region=${AWS::Region} --resource=Instance
-          /opt/aws/bin/cfn-signal --exit-code $? --stack=${AWS::StackName} --region=${AWS::Region} --resource=Instance
+      UserData:
+        Fn::Base64: !Sub |
+          #cloud-config
+          packages:
+            - python-setuptools
+            - curl
+            - tar
+          runcmd:
+            - tmpdir=$(mktemp -d)
+            - cd "$tmpdir"
+            - curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar -xzvf -
+            - easy_install ./aws-cfn-bootstrap-*/
+            - /usr/local/bin/cfn-init --verbose --stack="${AWS::StackName}" --region="${AWS::Region}" --resource=Instance
+            - /usr/local/bin/cfn-signal --exit-code $? --stack="${AWS::StackName}" --region="${AWS::Region}" --resource=Instance
       NetworkInterfaces:
       - AssociatePublicIpAddress: true
         DeleteOnTermination: true

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -163,10 +163,7 @@ Resources:
 
           runcmd:
             # Install cfn tools
-            - tmpdir=$(mktemp -d)
-            - cd "$tmpdir"
-            - curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar -xzvf -
-            - easy_install ./aws-cfn-bootstrap-*/
+            - easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 
             # Run cfn-init which will execute the metadata
             - /usr/local/bin/cfn-init --verbose --stack="${AWS::StackName}" --region="${AWS::Region}" --resource=Instance

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -39,37 +39,67 @@ Mappings:
     Ubuntu: {RegionMap: RegionMapUbuntu}
 
   RegionMapAmazonLinux:
-    ap-south-1: {AMI: ami-d7abd1b8}
-    eu-west-2: {AMI: ami-489f8e2c}
-    eu-west-1: {AMI: ami-ebd02392}
-    ap-northeast-2: {AMI: ami-8663bae8}
-    ap-northeast-1: {AMI: ami-4af5022c}
-    sa-east-1: {AMI: ami-d27203be}
-    ca-central-1: {AMI: ami-5ac17f3e}
-    ap-southeast-1: {AMI: ami-fdb8229e}
-    ap-southeast-2: {AMI: ami-30041c53}
-    eu-central-1: {AMI: ami-657bd20a}
-    us-east-1: {AMI: ami-4fffc834}
-    us-east-2: {AMI: ami-ea87a78f}
-    us-west-1: {AMI: ami-3a674d5a}
-    us-west-2: {AMI: ami-aa5ebdd2}
-
+    'ap-south-1':
+      AMI: 'ami-2ed19c41'
+    'eu-west-3':
+      AMI: 'ami-c8a017b5'
+    'eu-west-2':
+      AMI: 'ami-e3051987'
+    'eu-west-1':
+      AMI: 'ami-760aaa0f'
+    'ap-northeast-2':
+      AMI: 'ami-fc862292'
+    'ap-northeast-1':
+      AMI: 'ami-2803ac4e'
+    'sa-east-1':
+      AMI: 'ami-1678037a'
+    'ca-central-1':
+      AMI: 'ami-ef3b838b'
+    'ap-southeast-1':
+      AMI: 'ami-dd7935be'
+    'ap-southeast-2':
+      AMI: 'ami-1a668878'
+    'eu-central-1':
+      AMI: 'ami-e28d098d'
+    'us-east-1':
+      AMI: 'ami-6057e21a'
+    'us-east-2':
+      AMI: 'ami-aa1b34cf'
+    'us-west-1':
+      AMI: 'ami-1a033c7a'
+    'us-west-2':
+      AMI: 'ami-32d8124a'
   RegionMapUbuntu:
-    ap-south-1: {AMI: ami-099fe766}
-    eu-west-2: {AMI: ami-996372fd}
-    eu-west-1: {AMI: ami-785db401}
-    ap-northeast-2: {AMI: ami-d28a53bc}
-    ap-northeast-1: {AMI: ami-ea4eae8c}
-    sa-east-1: {AMI: ami-10186f7c}
-    ca-central-1: {AMI: ami-9818a7fc}
-    ap-southeast-1: {AMI: ami-6f198a0c}
-    ap-southeast-2: {AMI: ami-e2021d81}
-    eu-central-1: {AMI: ami-1e339e71}
-    us-east-1: {AMI: ami-cd0f5cb6}
-    us-east-2: {AMI: ami-10547475}
-    us-west-1: {AMI: ami-09d2fb69}
-    us-west-2: {AMI: ami-6e1a0117}
-
+    'ap-south-1':
+      AMI: 'ami-84dc94eb'
+    'eu-west-3':
+      AMI: 'ami-794bfc04'
+    'eu-west-2':
+      AMI: 'ami-22415846'
+    'eu-west-1':
+      AMI: 'ami-63b0341a'
+    'ap-northeast-2':
+      AMI: 'ami-5027813e'
+    'ap-northeast-1':
+      AMI: 'ami-42ca4724'
+    'sa-east-1':
+      AMI: 'ami-8181c7ed'
+    'ca-central-1':
+      AMI: 'ami-b0c67cd4'
+    'ap-southeast-1':
+      AMI: 'ami-29aece55'
+    'ap-southeast-2':
+      AMI: 'ami-9b8076f9'
+    'eu-central-1':
+      AMI: 'ami-13b8337c'
+    'us-east-1':
+      AMI: 'ami-3dec9947'
+    'us-east-2':
+      AMI: 'ami-597d553c'
+    'us-west-1':
+      AMI: 'ami-1a17137a'
+    'us-west-2':
+      AMI: 'ami-a2e544da'
 Conditions:
   UseCrossAccountIAM: !Not [!Equals [!Ref AssumeRole, '']]
   UseLocalIAM: !Equals [!Ref AssumeRole, '']

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -128,7 +128,7 @@ Resources:
         Version: 2012-10-17
         Statement:
         - Effect: Allow
-          Action: 
+          Action:
           - iam:ListUsers
           - iam:GetGroup
           Resource: '*'
@@ -153,17 +153,27 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #cloud-config
+
           packages:
+            # Install packages needed to install the cloudformation bootstrap from source
+            # (doing this to be more cross platform compatible)
             - python-setuptools
             - curl
             - tar
+
           runcmd:
+            # Install cfn tools
             - tmpdir=$(mktemp -d)
             - cd "$tmpdir"
             - curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar -xzvf -
             - easy_install ./aws-cfn-bootstrap-*/
+
+            # Run cfn-init which will execute the metadata
             - /usr/local/bin/cfn-init --verbose --stack="${AWS::StackName}" --region="${AWS::Region}" --resource=Instance
+
+            # Signal success/failure to the cloudformation stack
             - /usr/local/bin/cfn-signal --exit-code $? --stack="${AWS::StackName}" --region="${AWS::Region}" --resource=Instance
+
       NetworkInterfaces:
       - AssociatePublicIpAddress: true
         DeleteOnTermination: true
@@ -171,6 +181,7 @@ Resources:
         DeviceIndex: 0
         GroupSet:
         - !Ref SecurityGroup
+
       Tags:
       - Key: Name
         Value: AWS EC2 SSH access with IAM showcase
@@ -179,16 +190,22 @@ Resources:
       AWS::CloudFormation::Init:
         config:
           files:
+            # Pull down the install script directly from gihub
             /opt/install.sh:
               mode: '000755'
               owner: root
               group: root
               source: !Sub https://raw.githubusercontent.com/ebmeierj/aws-ec2-ssh/${EcsSshVersion}/install.sh
+
           commands:
+            # Run the install script
             01_install_ec2_ssh:
               command: !Sub EC2SSH_GITHUB_VERSION=${EcsSshVersion} ./install.sh -a "${AssumeRole}"
               cwd: /opt
 
+    # This creation policy tells cloudformation to wait for a signal (sent in the userdata portion of the config) before
+    # considering the resource creation to be complete. The resource and stack creation will fail if a signal is not received
+    # by the timeout.
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/showcase.yaml
+++ b/showcase.yaml
@@ -1,182 +1,154 @@
 ---
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'AWS EC2 SSH access with IAM showcase'
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS EC2 SSH access with IAM showcase
 Parameters:
   VPC:
-    Type: 'AWS::EC2::VPC::Id'
-    Description: 'The VPC the EC2 instance is launched into.'
+    Type: AWS::EC2::VPC::Id
+    Description: The VPC the EC2 instance is launched into
+
   Subnet:
-    Type: 'AWS::EC2::Subnet::Id'
-    Description: 'The subnet the EC2 instance is launched into.'
+    Type: AWS::EC2::Subnet::Id
+    Description: The subnet the EC2 instance is launched into
+
   AssumeRole:
-    Type: 'String'
-    Description: 'Optional IAM role ARN to assume to get the IAM users from another account'
+    Type: String
+    Description: Optional IAM role ARN to assume to get the IAM users from another account
     Default: ''
+
   KeyName:
-    Description: 'Optional key pair of the ec2-user to establish a SSH connection to the EC2 instance when things go wrong.'
+    Description: Optional key pair of the ec2-user to establish a SSH connection to the EC2 instance when things go wrong
     Type: String
     Default: ''
+
   OS:
-    Description: 'Operating system'
+    Description: Operating system
     Type: String
-    Default: 'AmazonLinux'
+    Default: AmazonLinux
     AllowedValues:
     - AmazonLinux
     - Ubuntu
+
   EcsSshVersion:
     Type: String
     Default: master
     Description: The github version of the ec2 ssh config scripts to use
+
 Mappings:
   OSMap:
-    AmazonLinux:
-      RegionMap: RegionMapAmazonLinux
-    Ubuntu:
-      RegionMap: RegionMapUbuntu
+    AmazonLinux: {RegionMap: RegionMapAmazonLinux}
+    Ubuntu: {RegionMap: RegionMapUbuntu}
+
   RegionMapAmazonLinux:
-    'ap-south-1':
-      AMI: 'ami-d7abd1b8'
-    'eu-west-2':
-      AMI: 'ami-489f8e2c'
-    'eu-west-1':
-      AMI: 'ami-ebd02392'
-    'ap-northeast-2':
-      AMI: 'ami-8663bae8'
-    'ap-northeast-1':
-      AMI: 'ami-4af5022c'
-    'sa-east-1':
-      AMI: 'ami-d27203be'
-    'ca-central-1':
-      AMI: 'ami-5ac17f3e'
-    'ap-southeast-1':
-      AMI: 'ami-fdb8229e'
-    'ap-southeast-2':
-      AMI: 'ami-30041c53'
-    'eu-central-1':
-      AMI: 'ami-657bd20a'
-    'us-east-1':
-      AMI: 'ami-4fffc834'
-    'us-east-2':
-      AMI: 'ami-ea87a78f'
-    'us-west-1':
-      AMI: 'ami-3a674d5a'
-    'us-west-2':
-      AMI: 'ami-aa5ebdd2'
+    ap-south-1: {AMI: ami-d7abd1b8}
+    eu-west-2: {AMI: ami-489f8e2c}
+    eu-west-1: {AMI: ami-ebd02392}
+    ap-northeast-2: {AMI: ami-8663bae8}
+    ap-northeast-1: {AMI: ami-4af5022c}
+    sa-east-1: {AMI: ami-d27203be}
+    ca-central-1: {AMI: ami-5ac17f3e}
+    ap-southeast-1: {AMI: ami-fdb8229e}
+    ap-southeast-2: {AMI: ami-30041c53}
+    eu-central-1: {AMI: ami-657bd20a}
+    us-east-1: {AMI: ami-4fffc834}
+    us-east-2: {AMI: ami-ea87a78f}
+    us-west-1: {AMI: ami-3a674d5a}
+    us-west-2: {AMI: ami-aa5ebdd2}
+
   RegionMapUbuntu:
-    'ap-south-1':
-      AMI: 'ami-099fe766'
-    'eu-west-2':
-      AMI: 'ami-996372fd'
-    'eu-west-1':
-      AMI: 'ami-785db401'
-    'ap-northeast-2':
-      AMI: 'ami-d28a53bc'
-    'ap-northeast-1':
-      AMI: 'ami-ea4eae8c'
-    'sa-east-1':
-      AMI: 'ami-10186f7c'
-    'ca-central-1':
-      AMI: 'ami-9818a7fc'
-    'ap-southeast-1':
-      AMI: 'ami-6f198a0c'
-    'ap-southeast-2':
-      AMI: 'ami-e2021d81'
-    'eu-central-1':
-      AMI: 'ami-1e339e71'
-    'us-east-1':
-      AMI: 'ami-cd0f5cb6'
-    'us-east-2':
-      AMI: 'ami-10547475'
-    'us-west-1':
-      AMI: 'ami-09d2fb69'
-    'us-west-2':
-      AMI: 'ami-6e1a0117'
+    ap-south-1: {AMI: ami-099fe766}
+    eu-west-2: {AMI: ami-996372fd}
+    eu-west-1: {AMI: ami-785db401}
+    ap-northeast-2: {AMI: ami-d28a53bc}
+    ap-northeast-1: {AMI: ami-ea4eae8c}
+    sa-east-1: {AMI: ami-10186f7c}
+    ca-central-1: {AMI: ami-9818a7fc}
+    ap-southeast-1: {AMI: ami-6f198a0c}
+    ap-southeast-2: {AMI: ami-e2021d81}
+    eu-central-1: {AMI: ami-1e339e71}
+    us-east-1: {AMI: ami-cd0f5cb6}
+    us-east-2: {AMI: ami-10547475}
+    us-west-1: {AMI: ami-09d2fb69}
+    us-west-2: {AMI: ami-6e1a0117}
+
 Conditions:
   UseCrossAccountIAM: !Not [!Equals [!Ref AssumeRole, '']]
   UseLocalIAM: !Equals [!Ref AssumeRole, '']
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
+
 Resources:
   SecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: ssh
       VpcId: !Ref VPC
       SecurityGroupIngress:
-      - CidrIp: '0.0.0.0/0'
+      - CidrIp: 0.0.0.0/0
         IpProtocol: tcp
         FromPort: 22
         ToPort: 22
+
   InstanceProfile:
-    Type: 'AWS::IAM::InstanceProfile'
+    Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
       - !Ref Role
+
   Role:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Effect: Allow
           Principal:
-            Service: 'ec2.amazonaws.com'
-          Action: 'sts:AssumeRole'
+            Service: ec2.amazonaws.com
+          Action: sts:AssumeRole
       Path: /
+
   CrossAccountRolePolicy:
-    Type: 'AWS::IAM::Policy'
+    Type: AWS::IAM::Policy
     Condition: UseCrossAccountIAM
     Properties:
       PolicyName: crossaccountiam
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
-            Action: 'sts:AssumeRole'
+            Action: sts:AssumeRole
             Resource: !Ref AssumeRole
       Roles:
         - !Ref Role
+
   LocalRolePolicy:
-    Type: 'AWS::IAM::Policy'
+    Type: AWS::IAM::Policy
     Condition: UseLocalIAM
     Properties:
       PolicyName: iam
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Effect: Allow
           Action: 
-          - 'iam:ListUsers'
-          - 'iam:GetGroup'
+          - iam:ListUsers
+          - iam:GetGroup
           Resource: '*'
         - Effect: Allow
           Action:
-          - 'iam:ListSSHPublicKeys'
-          - 'iam:GetSSHPublicKey'
-          Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:user/*'
+          - iam:ListSSHPublicKeys
+          - iam:GetSSHPublicKey
+          Resource: !Sub arn:aws:iam::${AWS::AccountId}:user/*
         - Effect: Allow
-          Action: 'ec2:DescribeTags'
+          Action: ec2:DescribeTags
           Resource: '*'
       Roles:
         - !Ref Role
+
   Instance:
     Type: AWS::EC2::Instance
-    Metadata:
-      'AWS::CloudFormation::Init':
-        config:
-          files:
-            /opt/install.sh:
-              mode: '000755'
-              owner: root
-              group: root
-              source: !Sub https://raw.githubusercontent.com/ebmeierj/aws-ec2-ssh/${EcsSshVersion}/install.sh
-          commands:
-            01_install_ec2_ssh:
-              command: !Sub EC2SSH_GITHUB_VERSION=${EcsSshVersion} ./install.sh -a "${AssumeRole}"
-              cwd: /opt
     Properties:
       ImageId: !FindInMap [!FindInMap [OSMap, !Ref OS, RegionMap], !Ref 'AWS::Region', AMI]
       IamInstanceProfile: !Ref InstanceProfile
-      InstanceType: 't2.micro'
+      InstanceType: t2.micro
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
       UserData:
         Fn::Base64: !Sub |
@@ -201,12 +173,28 @@ Resources:
         - !Ref SecurityGroup
       Tags:
       - Key: Name
-        Value: 'AWS EC2 SSH access with IAM showcase'
+        Value: AWS EC2 SSH access with IAM showcase
+
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          files:
+            /opt/install.sh:
+              mode: '000755'
+              owner: root
+              group: root
+              source: !Sub https://raw.githubusercontent.com/ebmeierj/aws-ec2-ssh/${EcsSshVersion}/install.sh
+          commands:
+            01_install_ec2_ssh:
+              command: !Sub EC2SSH_GITHUB_VERSION=${EcsSshVersion} ./install.sh -a "${AssumeRole}"
+              cwd: /opt
+
     CreationPolicy:
       ResourceSignal:
         Count: 1
         Timeout: PT15M
+
 Outputs:
   PublicName:
-    Description: 'The public name of the EC2 instance.'
-    Value: !GetAtt 'Instance.PublicDnsName'
+    Description: The public name of the EC2 instance
+    Value: !GetAtt Instance.PublicDnsName


### PR DESCRIPTION
- Made some changes to make the code more consistent between AmazonLinux and Ubuntu.
- Allow for using a specific version of the library (defaults to master)
- Limit required programs to tar, curl, and python-setuptools which are more widely available
- Re-formatted CF script