### PR TITLE
Add test to determine init system for sshd restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,8 +144,29 @@ chmod 0644 /etc/cron.d/import_users
 
 $IMPORT_USERS_SCRIPT_FILE
 
-if [ -f "/etc/init.d/sshd" ]; then
-  service sshd restart
+# Restart sshd using an appropriate method based on the currently running init daemon
+# Note that systemd can return "running" or "degraded" (If a systemd unit has failed)
+# This was observed on the RHEL 7.3 AMI, so it's added for completeness
+# systemd is also not standardized in the name of the ssh service, nor in the places
+# where the unit files are stored.
+
+if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then
+  if [ -f "/usr/lib/systemd/system/sshd.service" ] || [ -f "/lib/systemd/system/sshd.service" ]; then
+    systemctl restart sshd.service
+  else
+    systemctl restart ssh.service
+  fi
+  systemctl restart sshd.service
+elif [[ `/sbin/init --version` =~ upstart ]]; then
+  if [ -f "/etc/init.d/sshd" ]; then
+    service sshd restart
+  else
+    service ssh restart
+  fi
 else
-  service ssh restart
+  if [ -f "/etc/init.d/sshd" ]; then
+    /etc/init.d/sshd restart
+  else
+    /etc/init.d/ssh restart
+  fi
 fi


### PR DESCRIPTION
In the install file, I've added a simple test to determine what init
system is currently on the system, and to select the correct restart
command for sshd that is required.

This is tested on the following OSes in EC2:
* Amazon Linux 2017.09 (using upstart)
* Ubuntu 16.04.3 LTS (using systemd)
* SUSE Enterprise Server 12 SP3 (using systemd)
* RHEL 7.3 (using systemd)