### PR TITLE
Support for systemd, SELinux, and SUSE

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -42,7 +42,7 @@ fi
 : ${USERADD_PROGRAM:="/usr/sbin/useradd"}
 
 # Possibility to provide custom useradd arguments
-: ${USERADD_ARGS:="--create-home --shell /bin/bash"}
+: ${USERADD_ARGS:="--user-group --create-home --shell /bin/bash"}
 
 # Initizalize INSTANCE variable
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/install.sh
+++ b/install.sh
@@ -148,17 +148,25 @@ chmod 0644 /etc/cron.d/import_users
 
 $IMPORT_USERS_SCRIPT_FILE
 
+# In order to support SELinux in Enforcing mode, we need to tell SELinux that it
+# should have the nis_enabled boolean turned on (so it should expect login services
+# like PAM and sshd to make calls to get public keys from a remote server)
+#
+# This is observed on CentOS 7 and RHEL 7
+
+if [[ `which getenforce` -eq "0" ]]; then
+  if [[ `getenforce | grep -q "Enforcing"` -eq "0" ]]; then
+    setsebool -P nis_enabled on
+  fi
+fi
+
 # Restart sshd using an appropriate method based on the currently running init daemon
 # Note that systemd can return "running" or "degraded" (If a systemd unit has failed)
 # This was observed on the RHEL 7.3 AMI, so it's added for completeness
 # systemd is also not standardized in the name of the ssh service, nor in the places
 # where the unit files are stored.
 
-# Capture the return code and use that to determine if we have the command available
-which systemctl > /dev/null 2>&1
-retval=$?
-
-if [[ "$retval" -eq "0" ]]; then
+if [[ `which systemctl` -eq "0" ]]; then
   if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then
     if [ -f "/usr/lib/systemd/system/sshd.service" ] || [ -f "/lib/systemd/system/sshd.service" ]; then
       systemctl restart sshd.service

--- a/install.sh
+++ b/install.sh
@@ -124,13 +124,17 @@ fi
 if grep -q '#AuthorizedKeysCommand none' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    if ! grep -q "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 if grep -q '#AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    if ! grep -q 'AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 cat > /etc/cron.d/import_users << EOF

--- a/install.sh
+++ b/install.sh
@@ -154,11 +154,16 @@ $IMPORT_USERS_SCRIPT_FILE
 #
 # This is observed on CentOS 7 and RHEL 7
 
-if [[ `which getenforce` -eq "0" ]]; then
+# Capture the return code and use that to determine if we have the command available
+which getenforce > /dev/null 2>&1
+retval=$?
+
+if [[ "$retval" -eq "0" ]]; then
   if [[ `getenforce | grep -q "Enforcing"` -eq "0" ]]; then
     setsebool -P nis_enabled on
   fi
 fi
+
 
 # Restart sshd using an appropriate method based on the currently running init daemon
 # Note that systemd can return "running" or "degraded" (If a systemd unit has failed)
@@ -166,7 +171,11 @@ fi
 # systemd is also not standardized in the name of the ssh service, nor in the places
 # where the unit files are stored.
 
-if [[ `which systemctl` -eq "0" ]]; then
+# Capture the return code and use that to determine if we have the command available
+which systemctl > /dev/null 2>&1
+retval=$?
+
+if [[ "$retval" -eq "0" ]]; then
   if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then
     if [ -f "/usr/lib/systemd/system/sshd.service" ] || [ -f "/lib/systemd/system/sshd.service" ]; then
       systemctl restart sshd.service

--- a/install.sh
+++ b/install.sh
@@ -155,9 +155,11 @@ $IMPORT_USERS_SCRIPT_FILE
 # This is observed on CentOS 7 and RHEL 7
 
 # Capture the return code and use that to determine if we have the command available
+retval=0
 which getenforce > /dev/null 2>&1 || retval=$?
 
 if [[ "$retval" -eq "0" ]]; then
+  retval=0
   selinuxenabled || retval=$?
   if [[ "$retval" -eq "0" ]]; then
     setsebool -P nis_enabled on
@@ -172,6 +174,7 @@ fi
 # where the unit files are stored.
 
 # Capture the return code and use that to determine if we have the command available
+retval=0
 which systemctl > /dev/null 2>&1 || retval=$?
 
 if [[ "$retval" -eq "0" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -144,8 +144,34 @@ chmod 0644 /etc/cron.d/import_users
 
 $IMPORT_USERS_SCRIPT_FILE
 
-if [ -f "/etc/init.d/sshd" ]; then
-  service sshd restart
+# Restart sshd using an appropriate method based on the currently running init daemon
+# Note that systemd can return "running" or "degraded" (If a systemd unit has failed)
+# This was observed on the RHEL 7.3 AMI, so it's added for completeness
+# systemd is also not standardized in the name of the ssh service, nor in the places
+# where the unit files are stored.
+
+# Capture the return code and use that to determine if we have the command available
+which systemctl > /dev/null 2>&1
+retval=$?
+
+if [[ "$retval" -eq "0" ]]; then
+  if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then
+    if [ -f "/usr/lib/systemd/system/sshd.service" ] || [ -f "/lib/systemd/system/sshd.service" ]; then
+      systemctl restart sshd.service
+    else
+      systemctl restart ssh.service
+    fi
+  fi
+elif [[ `/sbin/init --version` =~ upstart ]]; then
+    if [ -f "/etc/init.d/sshd" ]; then
+      service sshd restart
+    else
+      service ssh restart
+    fi
 else
-  service ssh restart
+  if [ -f "/etc/init.d/sshd" ]; then
+    /etc/init.d/sshd restart
+  else
+    /etc/init.d/ssh restart
+  fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -155,11 +155,17 @@ $IMPORT_USERS_SCRIPT_FILE
 # This is observed on CentOS 7 and RHEL 7
 
 # Capture the return code and use that to determine if we have the command available
+# We also want to continue on non-zero exit codes, because this determines if we have
+# the command available to us
+set +e
 which getenforce > /dev/null 2>&1
 retval=$?
+set -e
 
 if [[ "$retval" -eq "0" ]]; then
-  if [[ `getenforce | grep -q "Enforcing"` -eq "0" ]]; then
+  selinuxenabled
+  retval=$?
+  if [[ "$retval" -eq "0" ]]; then
     setsebool -P nis_enabled on
   fi
 fi
@@ -172,8 +178,12 @@ fi
 # where the unit files are stored.
 
 # Capture the return code and use that to determine if we have the command available
+# We also want to continue on non-zero exit codes, because this determines if we have
+# the command available to us
+set +e
 which systemctl > /dev/null 2>&1
 retval=$?
+set -e
 
 if [[ "$retval" -eq "0" ]]; then
   if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then

--- a/install.sh
+++ b/install.sh
@@ -155,16 +155,10 @@ $IMPORT_USERS_SCRIPT_FILE
 # This is observed on CentOS 7 and RHEL 7
 
 # Capture the return code and use that to determine if we have the command available
-# We also want to continue on non-zero exit codes, because this determines if we have
-# the command available to us
-set +e
-which getenforce > /dev/null 2>&1
-retval=$?
-set -e
+which getenforce > /dev/null 2>&1 || retval=$?
 
 if [[ "$retval" -eq "0" ]]; then
-  selinuxenabled
-  retval=$?
+  selinuxenabled || retval=$?
   if [[ "$retval" -eq "0" ]]; then
     setsebool -P nis_enabled on
   fi
@@ -178,12 +172,7 @@ fi
 # where the unit files are stored.
 
 # Capture the return code and use that to determine if we have the command available
-# We also want to continue on non-zero exit codes, because this determines if we have
-# the command available to us
-set +e
-which systemctl > /dev/null 2>&1
-retval=$?
-set -e
+which systemctl > /dev/null 2>&1 || retval=$?
 
 if [[ "$retval" -eq "0" ]]; then
   if [[ (`systemctl is-system-running` =~ running) || (`systemctl is-system-running` =~ degraded) ]]; then


### PR DESCRIPTION
The following is an overview of the changes that are in this PR:

* Support multiple init platforms (specifically `systemd`, `upstart`, and legacy `SysV` init scripts)
* Support SUSE and other distros where `USERGROUPS_ENAB` is set to `no` in `/etc/login.defs`
* Support SELinux enforcing distros (like CentOS and RHEL) by appropriately setting the NIS boolean (to allow outbound communication to a remote location to fetch user info)
* Add a small check into the `install.sh` script to stop it from spamming `/etc/ssh/sshd_config` with the configuration directives when they already exist (e.g. if a user were to run `install.sh` twice)

The `systemd` changes should also search for both of the styles of naming the `sshd` service. On Ubuntu 16.04 LTS (and likely others in the Debian family), the service is named `ssh.service`. Everywhere else that I tested, it is named `sshd.service`. 
Helpfully, Canonical puts an alias line in their unit file, but I feel it's more correct to search for the unit file and then use that to make the correct call.

For SUSE, this is just a matter of explicitly telling `useradd(8)` to create a group for each user. The option has no effect on other distros (as that was default behavior), but it's probably better to be explicit with the call.

For SELinux, we simply check if we have SELinux utilities installed (which are required if you use the SELinux kernel modules), and if they exist, call the `selinuxenabled` command to get if SELinux is explicitly disabled. 
If it's disabled (as on Amazon Linux), we ignore setting the boolean as it would have no effect. 
If it is enabled (and it doesn't matter if SELinux is in Permissive or Enforcing mode), we set the boolean so we don't clog up the audit logs (Permissive mode), or get blocked (Enforcing mode).

This has been tested on the following AMIs (All AMI IDs are for region us-east-2):
* RHEL 7.4 - RHEL-7.4_HVM_GA-20170808-x86_64-2-Hourly2-GP2 (ami-cfdafaaa)
* CentOS Linux 7 x86_64 HVM EBS 1703_01 (ami-9cbf9bf9)
* Ubuntu 16.04 LTS - ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20171121.1 (ami-82f4dae7)
* SUSE 12 - suse-sles-12-sp3-v20171121-hvm-ssd-x86_64 (ami-36f5db53)
* Amazon Linux - amzn-ami-hvm-2017.09.1.20171120-x86_64-gp2 (ami-15e9c770)

This should resolve the following open issues:
#84