### PR TITLE
Add ssh service to showcase to force restart of service

### DIFF
--- a/showcase.yaml
+++ b/showcase.yaml
@@ -145,7 +145,7 @@ Resources:
         Version: '2012-10-17'
         Statement:
         - Effect: Allow
-          Action: 
+          Action:
           - 'iam:ListUsers'
           - 'iam:GetGroup'
           Resource: '*'
@@ -181,6 +181,31 @@ Resources:
             a_install:
               command: !Sub './install.sh -a "${AssumeRole}"'
               cwd: '/opt'
+          services:
+            sysvinit: !If
+              - UseUbuntu
+              -
+                ssh:
+                  enabled: "true"
+                  ensureRunning: "true"
+                  sources:
+                    - "/opt"
+                  files:
+                    - "/etc/ssh/sshd_config"
+                    - "/opt/install.sh"
+                  commands:
+                    - "a_install"
+              -
+                sshd:
+                  enabled: "true"
+                  ensureRunning: "true"
+                  sources:
+                    - "/opt"
+                  files:
+                    - "/etc/ssh/sshd_config"
+                    - "/opt/install.sh"
+                  commands:
+                    - "a_install"
     Properties:
       ImageId: !FindInMap [!FindInMap [OSMap, !Ref OS, RegionMap], !Ref 'AWS::Region', AMI]
       IamInstanceProfile: !Ref InstanceProfile


### PR DESCRIPTION
I've added the `services:` section to the `AWS::CloudFormation::Init` metadata.

This should force restarting of sshd for both Amazon Linux and Ubuntu.

Maven test suite is showing success on both tests in the test suite.