### PR TITLE
Build .deb package for Ubuntu 16.04

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -55,3 +55,34 @@ Default user: centos
 ```
 $ for region in $regions; do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=CentOS Linux 7 x86_64 HVM EBS 1708_11.01" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
+
+## Building packages
+
+### `.deb` for Ubuntu 16.04
+
+If you want to build a `.deb` package, you can use `fpm`, which requires `ruby`.
+To install on Ubuntu 16.04 LTS:
+```
+apt-get install ruby ruby-dev rubygems build-essential && gem install --no-ri --no-rdoc fpm
+```
+You can then run `fpm` to execute.
+
+To build the package, run the following (replacing <> values):
+```
+fpm -t deb -n aws-ec2-ssh -v <VERSION_STAMP> -d bash --license mit -a all -m "<MAINTAINER>" --vendor "widdix GmbH" --url "https://cloudonaut.io/manage-aws-ec2-ssh-access-with-iam/" --description "Manage AWS EC2 SSH access with IAM" --after-install pkg/postinst --after-remove pkg/postrm --config-files /etc/aws-ec2-ssh.conf -s dir  import_users.sh=/usr/bin/ authorized_keys_command.sh=/usr/bin/ aws-ec2-ssh.conf=/etc/ pkg/import_users=/etc/cron.d/
+```
+You can then have your nice shiny `.deb` available for use.
+
+### `.rpm` for Amazon Linux
+
+To build an RPM, you will need to have both `rpm-build` and `rpmdevtools` packages installed. You will also need a build tree set up by using `rpmdev-setuptree`. This creates the build tree in your home directory.
+
+Then use the following commands to build the package from the repository root.
+
+```
+export VERSION=<RELEASED_VERSION_TO_BUILD>
+spectool --define="jenkins_version ${VERSION}" --define="jenkins_release 1" --define="jenkins_archive v${VERSION}" --define="jenkins_suffix ${VERSION}" -g -R aws-ec2-ssh.spec
+rpmbuild --define="jenkins_version ${VERSION}" --define="jenkins_release 1" --define="jenkins_archive v${VERSION}" --define="jenkins_suffix ${VERSION}" -bb aws-ec2-ssh.spec
+```
+
+You will then have an RPM built in `~/rpmbuild/RPMS/noarch/` available for use.

--- a/pkg/import_users
+++ b/pkg/import_users
@@ -1,0 +1,1 @@
+*/10 * * * * root /usr/bin/import_users.sh

--- a/pkg/postinst
+++ b/pkg/postinst
@@ -1,0 +1,23 @@
+# We will use the same code here as in the install.sh to detect if we need to use sed -i or append the configuartion
+# to the sshd_config file.
+# Even though we have a debconf managed config file, upgrading openssh-server package shouldn't overwrite an existing
+# sshd_config file, according to the base package's postinst script
+if grep -q '#AuthorizedKeysCommand none' /etc/ssh/sshd_config; then
+    sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand /usr/bin/authorized_keys_command.sh:g" /etc/ssh/sshd_config
+else
+    if ! grep -q "AuthorizedKeysCommand /usr/bin/authorized_keys_command.sh" /etc/ssh/sshd_config; then
+        echo "AuthorizedKeysCommand /usr/bin/authorized_keys_command.sh" >> /etc/ssh/sshd_config
+    fi
+fi
+
+if grep -q '#AuthorizedKeysCommandUser nobody' /etc/ssh/sshd_config; then
+    sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" /etc/ssh/sshd_config
+else
+    if ! grep -q 'AuthorizedKeysCommandUser nobody' /etc/ssh/sshd_config; then
+        echo "AuthorizedKeysCommandUser nobody" >> /etc/ssh/sshd_config
+    fi
+fi
+systemctl restart ssh.service
+systemctl restart cron.service
+
+echo "To configure the aws-ec2-ssh package, edit /etc/aws-ec2-ssh.conf. No users will be synchronized before you do this."

--- a/pkg/postrm
+++ b/pkg/postrm
@@ -1,0 +1,47 @@
+# Post Removal Script
+
+# Helper functions
+# Get previously synced users
+function get_local_users() {
+    /usr/bin/getent group ${LOCAL_MARKER_GROUP} \
+        | cut -d : -f4- \
+        | sed "s/,/ /g"
+}
+
+function delete_local_user() {
+    # First, make sure no new sessions can be started
+    /usr/sbin/usermod -L -s /sbin/nologin "${1}" || true
+    # ask nicely and give them some time to shutdown
+    /usr/bin/pkill -15 -u "${1}" || true
+    sleep 5
+    # Dont want to close nicely? DIE!
+    /usr/bin/pkill -9 -u "${1}" || true
+    sleep 1
+    # Remove account now that all processes for the user are gone
+    $USERDEL_PROGRAM -f -r "${1}"
+    log "Deleted user ${1}"
+}
+
+# Clean Up sshd_config
+#
+# For removal, we should want to have these lines commented out in the configuration.
+# If the package is reinstalled, we grep for these commented lines and change them with sed
+sed -i 's:AuthorizedKeysCommand /usr/bin/authorized_keys_command.sh:#AuthorizedKeysCommand none:g' /etc/ssh/sshd_config
+sed -i 's:AuthorizedKeysCommandUser nobody:#AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
+
+# Clean Up cron file
+# The cronfile should clean itself up (It's not marked as config, so it will remove every time)
+# but we will want to remove any users that we synced.
+local_users=$(get_local_users | sort | uniq)
+for user in ${local_users}; do
+    delete_local_user "${user}"
+done
+
+# Clean Up our configuration file
+# Conf files generally are kept when using `apt-get remove` or `apt erase`. 
+# The user can specify that the config file be purged from `/etc` by using
+# `apt-get remove --purge` or `apt purge`
+# when removing the package, so we do nothing.
+
+systemctl restart ssh.service
+systemctl restart cron.service


### PR DESCRIPTION
There was a quick discussion in #104 about possibility of creating a .deb package that would work with Ubuntu 16.04.

The current RPM build with spec file is the correct way to build the RPM package, but Debian's toolkit for building .debs is a bit more obtuse. So I've leveraged [jordansissel/fpm](https://github.com/jordansissel/fpm) to build .deb package for the tree.

Currently it packages the current state of the tree, but it would be easy to wrap with a script that uses released versions, like the RPM spec file does.