### PR TITLE
speed up not controlled user authentication

### DIFF
--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -12,6 +12,13 @@ fi
 # instance you use this script runs in another.
 : ${ASSUMEROLE:=""}
 
+# Special group to mark users as being synced by our script
+: ${LOCAL_MARKER_GROUP:="iam-synced-users"}
+
+if ! getent group "${LOCAL_MARKER_GROUP}" | grep &>/dev/null "\b$1\b"; then
+  exit 1
+fi
+
 if [[ ! -z "${ASSUMEROLE}" ]]
 then
   STSCredentials=$(aws sts assume-role \


### PR DESCRIPTION
In case the user is not a member of the `LOCAL_MARKER_GROUP` then the script will not return anything anyway so fall fast will speed up the authentication, my own test show significant changes.
```
$ time ssh non-iam-user-for-backup@my-server /bin/true

real	0m3.152s
user	0m0.037s
sys	0m0.016s
$ time ssh non-iam-user-for-backup@my-server /bin/true

real	0m0.368s
user	0m0.048s
sys	0m0.007s
```