### PR TITLE
Added option to remove email domain from usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ This solution will use the following mapping for those special characters when c
 
 So instead of `name@email.com` you will need to use `name.at.email.com` when login via SSH.
 
+
+Optionally, set `STRIP_EMAILS_FROM_USERNAME=1` in the config file, in which case `user.name@email.com` will become simply `user.name`.
+
+Note that to reverse-engineer the remainder of the username, we look up the IAM users via the cli. This means usernames must be unique, exclusive of the email domain.
+E.g. `my.user@email.com` and `my.user@anotherEmail.com` will not be differentiated and will not be able to use this method.
+
+
 Linux user names may only be up to 32 characters long.
 
 ## Configuration

--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -33,12 +33,23 @@ then
   export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 fi
 
-UnsaveUserName="$1"
-UnsaveUserName=${UnsaveUserName//".plus."/"+"}
-UnsaveUserName=${UnsaveUserName//".equal."/"="}
-UnsaveUserName=${UnsaveUserName//".comma."/","}
-UnsaveUserName=${UnsaveUserName//".at."/"@"}
+raw_username="$1"
+raw_username=${raw_username//".plus."/"+"}
+raw_username=${raw_username//".equal."/"="}
+raw_username=${raw_username//".comma."/","}
 
-aws iam list-ssh-public-keys --user-name "$UnsaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read -r KeyId; do
-  aws iam get-ssh-public-key --user-name "$UnsaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
+if [ "${STRIP_EMAILS_FROM_USERNAME}" -eq 1 ]; then
+    iam_username=$(aws iam list-users --query "Users[*].[UserName]" --output text | fgrep "$raw_username@")
+
+    if [ $(echo "${iam_username}" | wc -w) -gt 1 ]; then
+        echo "Multiple IAM users matched: - exiting!"
+        echo "${iam_username}"
+        exit 2
+    fi
+else
+    iam_username=${raw_username//".at."/"@"}
+fi
+
+aws iam list-ssh-public-keys --user-name "${iam_username}" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read -r KeyId; do
+  aws iam get-ssh-public-key --user-name "${iam_username}" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
 done

--- a/import_users.sh
+++ b/import_users.sh
@@ -220,7 +220,11 @@ function clean_iam_username() {
     clean_username=${clean_username//"+"/".plus."}
     clean_username=${clean_username//"="/".equal."}
     clean_username=${clean_username//","/".comma."}
-    clean_username=${clean_username//"@"/".at."}
+    if [ "${STRIP_EMAILS_FROM_USERNAME}" -eq 1 ]; then
+        clean_username=${clean_username%%@*}
+    else
+        clean_username=${clean_username//"@"/".at."}
+    fi
     echo "${clean_username}"
 }
 


### PR DESCRIPTION
It's often the case that people will have their email addresses as their IAM usernames and I'd say it's pretty much always the case that they wouldn't want that as part of their local EC2 username.

This allows the option of stripping the domain from their username so `user.name@email.com` will become simply `user.name`.
Note that to reverse-engineer the remainder of the username, we look up the IAM users via the cli. This means usernames must be unique, exclusive of the email domain. E.g. `my.user@email.com` and `my.user@anotherEmail.com` will not be differentiated and will not be able to use this method.

I'd suggest this become the default behaviour, but have not made that the case in this PR in order to maintain backwards compatibility.