### PR TITLE
Support for deleted/non-existant IAM group

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -103,7 +103,9 @@ function get_iam_users() {
                 --group-name "${group}" \
                 --query "Users[].[UserName]" \
                 --output text \
-            | sed "s/\r//g"
+            3>&1 1>&2 2>&3 3>&- \    
+            | sed "s/\r//g" \
+            | sed "/\(NoSuchEntity\)/d"
         done
     fi
 }

--- a/import_users.sh
+++ b/import_users.sh
@@ -103,7 +103,7 @@ function get_iam_users() {
                 --group-name "${group}" \
                 --query "Users[].[UserName]" \
                 --output text \
-            3>&1 1>&2 2>&3 3>&- \    
+            3>&1 1>&2 2>&3 3>&- \
             | sed "s/\r//g" \
             | sed "/\(NoSuchEntity\)/d"
         done

--- a/import_users.sh
+++ b/import_users.sh
@@ -99,13 +99,13 @@ function get_iam_users() {
         | sed "s/\r//g"
     else
         for group in $(echo ${IAM_AUTHORIZED_GROUPS} | tr "," " "); do
-            aws iam get-group \
+            if ! aws iam get-group \
                 --group-name "${group}" \
                 --query "Users[].[UserName]" \
-                --output text \
-            3>&1 1>&2 2>&3 3>&- \
-            | sed "s/\r//g" \
-            | sed "/\(NoSuchEntity\)/d"
+                --output text;
+            then
+                continue;
+            fi
         done
     fi
 }
@@ -144,10 +144,13 @@ function get_sudoers_users() {
 
     [[ -z "${SUDOERS_GROUPS}" ]] || [[ "${SUDOERS_GROUPS}" == "##ALL##" ]] ||
         for group in $(echo "${SUDOERS_GROUPS}" | tr "," " "); do
-            aws iam get-group \
+            if ! aws iam get-group \
                 --group-name "${group}" \
                 --query "Users[].[UserName]" \
-                --output text
+                --output text;
+            then
+                continue;
+            fi
         done
 }
 

--- a/install.sh
+++ b/install.sh
@@ -143,8 +143,10 @@ SHELL=/bin/bash
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/aws/bin
 MAILTO=root
 HOME=/
-*/10 * * * * root $IMPORT_USERS_SCRIPT_FILE
+RANDOM_DELAY=19
+*/20 * * * * root $IMPORT_USERS_SCRIPT_FILE
 EOF
+
 chmod 0644 /etc/cron.d/import_users
 
 $IMPORT_USERS_SCRIPT_FILE

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ tmpdir=$(mktemp -d)
 
 cd "$tmpdir"
 
-git clone -b master https://github.com/widdix/aws-ec2-ssh.git
+git clone -b master https://github.com/nicholascowan/aws-ec2-ssh.git
 
 cd "$tmpdir/aws-ec2-ssh"
 


### PR DESCRIPTION
This allows the import logic to work if a group has been deleted or does not exist (optional group)

It does so by combining stdout and stderr and stripping any lines which contain "(NoSuchEntity)", as AWSCLI will return the following:

`An error occurred (NoSuchEntity) when calling the GetGroup operation: The group with name NonExistantGroup cannot be found.`

If this particular solution is declined, can we support this functionality in some other way? Thanks.