### PR TITLE
Make sure AuthorizedKeysCommandUser exists before setting it

### DIFF
--- a/authorized_keys_command.sh
+++ b/authorized_keys_command.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 if [ -z "$1" ]; then
   exit 1

--- a/import_users.sh
+++ b/import_users.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 function log() {
     /usr/bin/logger -i -p auth.info -t aws-ec2-ssh "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 show_help() {
 cat << EOF
@@ -136,9 +138,7 @@ fi
 
 ./install_configure_selinux.sh
 
-if ! ./install_configure_sshd.sh; then
-    exit 1
-fi
+./install_configure_sshd.sh
 
 cat > /etc/cron.d/import_users << EOF
 SHELL=/bin/bash

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,9 @@ fi
 
 ./install_configure_selinux.sh
 
-./install_configure_sshd.sh
+if ! ./install_configure_sshd.sh; then
+    exit 1
+fi
 
 cat > /etc/cron.d/import_users << EOF
 SHELL=/bin/bash

--- a/install_configure_selinux.sh
+++ b/install_configure_selinux.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 # In order to support SELinux in Enforcing mode, we need to tell SELinux that it
 # should have the nis_enabled boolean turned on (so it should expect login services

--- a/install_configure_sshd.sh
+++ b/install_configure_sshd.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 if grep -q '#AuthorizedKeysCommand none' "$SSHD_CONFIG_FILE"; then
   sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}:g" "$SSHD_CONFIG_FILE"

--- a/install_configure_sshd.sh
+++ b/install_configure_sshd.sh
@@ -3,15 +3,20 @@
 if grep -q '#AuthorizedKeysCommand none' "$SSHD_CONFIG_FILE"; then
   sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}:g" "$SSHD_CONFIG_FILE"
 else
-  if ! grep -q "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" "$SSHD_CONFIG_FILE"; then
+  if ! grep -q "^AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" "$SSHD_CONFIG_FILE"; then
     echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> "$SSHD_CONFIG_FILE"
   fi
 fi
 
-if grep -q '#AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
-  sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" "$SSHD_CONFIG_FILE"
-else
-  if ! grep -q 'AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
-    echo "AuthorizedKeysCommandUser nobody" >> "$SSHD_CONFIG_FILE"
+if grep -aq 'AuthorizedKeysCommandUser' "$(which sshd)"; then
+  if grep -q '#AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
+    sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" "$SSHD_CONFIG_FILE"
+  else
+    if ! grep -q '^AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
+      echo "AuthorizedKeysCommandUser nobody" >> "$SSHD_CONFIG_FILE"
+    fi
   fi
+else
+  echo 'AuthorizedKeysCommandUser not supported in sshd_config'
+  exit 1
 fi

--- a/install_restart_sshd.sh
+++ b/install_restart_sshd.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 # Restart sshd using an appropriate method based on the currently running init daemon
 # Note that systemd can return "running" or "degraded" (If a systemd unit has failed)


### PR DESCRIPTION
Thanks for making this unique, easy-to-use solution to a very common problem.

The default behavior was to drop the AuthorizedKeysCommandUser value into the codebase regardless of whether it was supported by the installed version of `openssh-server`.  The reason I wanted to add this snippet was because I noticed `sshd` is restarted even if the config is invalid. This would only be relevant where the `openssh-server` version is `< 6.1`. I know this would only be the case on old servers, but it's a simple way to protect users exploring your tooling.

If you have any suggestions for revision, I'm all ears. :)