### PR TITLE
Enhancement/centos6 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,9 @@ fi
 
 ./install_configure_selinux.sh
 
-./install_configure_sshd.sh
+if ! ./install_configure_sshd.sh; then
+    exit 1
+fi
 
 cat > /etc/cron.d/import_users << EOF
 SHELL=/bin/bash

--- a/install_configure_sshd.sh
+++ b/install_configure_sshd.sh
@@ -17,6 +17,11 @@ if grep -aq 'AuthorizedKeysCommandUser' "$SSHD_CONFIG_FILE"; then
     fi
   fi
 else
-  echo 'AuthorizedKeysCommandUser not supported in sshd_config'
-  exit 1
+  if grep -q '#AuthorizedKeysCommandRunAs nobody' "$SSHD_CONFIG_FILE"; then
+    sed -i "s:#AuthorizedKeysCommandRunAs nobody:AuthorizedKeysCommandRunAs nobody:g" "$SSHD_CONFIG_FILE"
+  else
+    if ! grep -q 'AuthorizedKeysCommandRunAs nobody' "$SSHD_CONFIG_FILE"; then
+      echo "AuthorizedKeysCommandRunAs nobody" >> "$SSHD_CONFIG_FILE"
+    fi
+  fi
 fi

--- a/install_configure_sshd.sh
+++ b/install_configure_sshd.sh
@@ -8,10 +8,15 @@ else
   fi
 fi
 
-if grep -q '#AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
-  sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" "$SSHD_CONFIG_FILE"
-else
-  if ! grep -q 'AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
-    echo "AuthorizedKeysCommandUser nobody" >> "$SSHD_CONFIG_FILE"
+if grep -aq 'AuthorizedKeysCommandUser' "$SSHD_CONFIG_FILE"; then
+  if grep -q '#AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
+    sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" "$SSHD_CONFIG_FILE"
+  else
+    if ! grep -q 'AuthorizedKeysCommandUser nobody' "$SSHD_CONFIG_FILE"; then
+      echo "AuthorizedKeysCommandUser nobody" >> "$SSHD_CONFIG_FILE"
+    fi
   fi
+else
+  echo 'AuthorizedKeysCommandUser not supported in sshd_config'
+  exit 1
 fi


### PR DESCRIPTION
I'm not sure whether there'd be any interest in adding CentOS 6 support, but this commit introduces an alternative method of enabling `AuthorizedKeysCommand` without disabling SELinux entirely that acts as a fallback when `nis_enabled` is not a valid variable to set.

Additionally, since you can't upgrade openssh-server to be `> 6.1` on CentOS 6, these changes use `AuthorizedKeysCommandRunAs` rather than `AuthorizedKeysCommandUser`.  The way I determined whether `AuthorizedKeysCommandUser` was available by `grep`ing the `sshd` binary for the string. For some reason, I can't do the same for `AuthorizedKeysCommandRunAs`. I don't know where it's hiding.

Let me know what you think. 