### PR TITLE
Install from latest release instead of master

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ tmpdir=$(mktemp -d)
 
 cd "$tmpdir"
 
-git clone -b master https://github.com/widdix/aws-ec2-ssh.git
+git clone -b v1.8.0 https://github.com/widdix/aws-ec2-ssh.git
 
 cd "$tmpdir/aws-ec2-ssh"
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-hv] [-a ARN] [-i GROUP,GROUP,...] [-l GROUP,GROUP,...] [-s GROUP] [-p PROGRAM] [-u "ARGUMENTS"]
+Usage: ${0##*/} [-hv] [-a ARN] [-i GROUP,GROUP,...] [-l GROUP,GROUP,...] [-s GROUP] [-p PROGRAM] [-u "ARGUMENTS"] [-r RELEASE]
 Install import_users.sh and authorized_key_commands.
 
     -h                 display this help and exit
@@ -23,6 +23,9 @@ Install import_users.sh and authorized_key_commands.
                        Defaults to '/usr/sbin/useradd'
     -u "useradd args"  Specify arguments to use with useradd.
                        Defaults to '--create-home --shell /bin/bash'
+    -r release         Specify a release of aws-ec2-ssh to download from GitHub. This argument is
+                       passed to \`git clone -b\` and so works with branches and tags.
+                       Defaults to 'master'
 
 
 EOF
@@ -39,8 +42,9 @@ LOCAL_GROUPS=""
 ASSUME_ROLE=""
 USERADD_PROGRAM=""
 USERADD_ARGS=""
+RELEASE="master"
 
-while getopts :hva:i:l:s: opt
+while getopts :hva:i:l:s:p:u:r: opt
 do
     case $opt in
         h)
@@ -67,6 +71,9 @@ do
             ;;
         u)
             USERADD_ARGS="$OPTARG"
+            ;;
+        r)
+            RELEASE="$OPTARG"
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -97,7 +104,7 @@ tmpdir=$(mktemp -d)
 
 cd "$tmpdir"
 
-git clone -b v1.8.0 https://github.com/widdix/aws-ec2-ssh.git
+git clone -b "$RELEASE" https://github.com/widdix/aws-ec2-ssh.git
 
 cd "$tmpdir/aws-ec2-ssh"
 


### PR DESCRIPTION
Make the install script idempotent by locking in the latest version number. This value needs to be updated each time a new release is pushed out.

An alternative solution would be to pass in the release version as an argument to this script. I think even if this option was to be added, it should still default to the release from which the install script was taken.

Without this change, the install script cannot reliably be used for idempotent builds.