### PR TITLE
Install script enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A picture is worth a thousand words:
 ![Architecture](./docs/architecture.png?raw=true "Architecture")
 
 * On first start, all IAM users are imported and local UNIX users are created
-* The import also runs every 10 minutes (via cron - calls [`import_users.sh`](./import_users.sh))
+* The import also runs every 10 minutes and after every reboot (via cron - calls [`import_users.sh`](./import_users.sh))
 * You can control which IAM users get a local UNIX user and are therefore able to login
    * all (default)
    * only those in specific IAM groups

--- a/install.sh
+++ b/install.sh
@@ -224,6 +224,7 @@ SHELL=/bin/bash
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/aws/bin
 MAILTO=root
 HOME=/
+@reboot      root $IMPORT_USERS_SCRIPT_FILE
 */10 * * * * root $IMPORT_USERS_SCRIPT_FILE
 EOF
 chmod 0644 /etc/cron.d/import_users

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,7 @@ fi
 
 cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
 cp import_users.sh $IMPORT_USERS_SCRIPT_FILE
+cat /dev/null > $MAIN_CONFIG_FILE
 
 if [ "${IAM_GROUPS}" != "" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -106,13 +106,29 @@ if ! [ -x "$(which git)" ]; then
     exit 1
 fi
 
-tmpdir=$(mktemp -d)
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-cd "$tmpdir"
+# check if install script is part of a local git clone or downloaded as standalone
+SOURCE_LOCATION=""
+if [ -f $SCRIPTPATH/aws-ec2-ssh.conf ] && [ -d $SCRIPTPATH/.git/ ]; then
+	SOURCE_LOCATION="local";
+else
+	SOURCE_LOCATION="github";
+fi
 
-git clone -b "$RELEASE" https://github.com/widdix/aws-ec2-ssh.git
+echo "Source location: $SOURCE_LOCATION"
 
-cd "$tmpdir/aws-ec2-ssh"
+if [ $SOURCE_LOCATION == "github" ]; then
+	tmpdir=$(mktemp -d)
+
+	cd "$tmpdir"
+
+	git clone -b "$RELEASE" https://github.com/widdix/aws-ec2-ssh.git
+	
+	cd "$tmpdir/aws-ec2-ssh"
+else
+	cd $SCRIPTPATH
+fi
 
 cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
 cp import_users.sh $IMPORT_USERS_SCRIPT_FILE


### PR DESCRIPTION
I made a few improvements to the `install.sh` script:
* Enabled setup of `IAM_AUTHORIZED_GROUPS_TAG` and `SUDOERS_GROUPS_TAG` in config file through `install.sh`
* Enabled clean reinstall through re-executing `install.sh`
* Use long-format arguments in `install.sh` to increase readability
* Let `install.sh` use local git clone as source (autodetected) instead of making a new github clone (useful when forking/developing)
