### PR TITLE
Implemented flexible local group assignments to select users

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A picture is worth a thousand words:
 
 ### Demo with CloudFormation
 
-1. Upload your public SSH key to IAM: 
+1. Upload your public SSH key to IAM:
    1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
    2. Click the row with your user
    3. Select the **Security Credentials** tab
@@ -51,7 +51,7 @@ A picture is worth a thousand words:
 
 ### Install via RPM
 
-1. Upload your public SSH key to IAM: 
+1. Upload your public SSH key to IAM:
    1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
    2. Click the row with your user
    3. Select the **Security Credentials** tab
@@ -66,7 +66,7 @@ A picture is worth a thousand words:
 
 ### Install via install.sh script
 
-1. Upload your public SSH key to IAM: 
+1. Upload your public SSH key to IAM:
    1. Open the Users section in the [IAM Management Console](https://console.aws.amazon.com/iam/home#users)
    2. Click the row with your user
    3. Select the **Security Credentials** tab
@@ -104,16 +104,18 @@ There are a couple of things you can configure by editing/creating the file `/et
 one or more of the following lines:
 
 ```
-ASSUMEROLE="IAM-role-arn"                      # IAM Role ARN for multi account. See below for more info
-IAM_AUTHORIZED_GROUPS="GROUPNAMES"             # Comma separated list of IAM groups to import
-SUDOERS_GROUPS="GROUPNAMES"                    # Comma seperated list of IAM groups that should have sudo access or `##ALL##` to allow all users
-IAM_AUTHORIZED_GROUPS_TAG="KeyTag"             # Key Tag of EC2 that contains a Comma separated list of IAM groups to import - IAM_AUTHORIZED_GROUPS_TAG will override IAM_AUTHORIZED_GROUPS, you can use only one of them 
-SUDOERS_GROUPS_TAG="KeyTag"                    # Key Tag of EC2 that contains a Comma separated list of IAM groups that should have sudo access - SUDOERS_GROUPS_TAG will override SUDOERS_GROUPS, you can use only one of them
-SUDOERSGROUP="GROUPNAME"                       # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
-LOCAL_MARKER_GROUP="iam-synced-users"          # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
-LOCAL_GROUPS="GROUPNAMES"                      # Comma seperated list of UNIX groups to add the users in
-USERADD_PROGRAM="/usr/sbin/useradd"            # The useradd program to use. defaults to `/usr/sbin/useradd`
-USERADD_ARGS="--create-home --shell /bin/bash" # Arguments for the useradd program. defaults to `--create-home --shell /bin/bash`
+ASSUMEROLE="IAM-role-arn"                         # IAM Role ARN for multi account. See below for more info
+IAM_AUTHORIZED_GROUPS="GROUPNAMES"                # Comma separated list of IAM groups to import
+SUDOERS_GROUPS="GROUPNAMES"                       # Comma seperated list of IAM groups that should have sudo access or `##ALL##` to allow all users
+IAM_AUTHORIZED_GROUPS_TAG="KeyTag"                # Key Tag of EC2 that contains a Comma separated list of IAM groups to import - IAM_AUTHORIZED_GROUPS_TAG will override IAM_AUTHORIZED_GROUPS, you can use only one of them
+SUDOERS_GROUPS_TAG="KeyTag"                       # Key Tag of EC2 that contains a Comma separated list of IAM groups that should have sudo access - SUDOERS_GROUPS_TAG will override SUDOERS_GROUPS, you can use only one of them
+SUDOERSGROUP="GROUPNAME"                          # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
+LOCAL_MARKER_GROUP="iam-synced-users"             # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
+LOCAL_GROUPS="GROUPNAMES"                         # Comma seperated list of UNIX groups to add the users in
+LOCAL_GROUP_MAP='{"local-group": ["iam-group"]}'  # JSON string indicating iam-groups to add to local-groups
+LOCAL_GROUP_MAP_TAG="KeyTag"                      # Key Tag of EC2 that contains a value for LOCAL_GROUP_MAP
+USERADD_PROGRAM="/usr/sbin/useradd"               # The useradd program to use. defaults to `/usr/sbin/useradd`
+USERADD_ARGS="--create-home --shell /bin/bash"    # Arguments for the useradd program. defaults to `--create-home --shell /bin/bash`
 ```
 
 The LOCAL_MARKER_GROUP will be created if it does not exist. BEWARE: DO NOT add any manually created users

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A picture is worth a thousand words:
 ![Architecture](./docs/architecture.png?raw=true "Architecture")
 
 * On first start, all IAM users are imported and local UNIX users are created
-* The import also runs every 10 minutes (via cron - calls [`import_users.sh`](./import_users.sh))
+* The import also runs every 10 minutes and after every reboot (via cron - calls [`import_users.sh`](./import_users.sh))
 * You can control which IAM users get a local UNIX user and are therefore able to login
    * all (default)
    * only those in specific IAM groups

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ one or more of the following lines:
 
 ```
 ASSUMEROLE="IAM-role-arn"                         # IAM Role ARN for multi account. See below for more info
-IAM_AUTHORIZED_GROUPS="GROUPNAMES"                # Comma separated list of IAM groups to import
+IAM_AUTHORIZED_GROUPS="GROUPNAMES"                # Comma separated list of IAM groups to import or `##ALL##` to import all available IAM users
 SUDOERS_GROUPS="GROUPNAMES"                       # Comma seperated list of IAM groups that should have sudo access or `##ALL##` to allow all users
 IAM_AUTHORIZED_GROUPS_TAG="KeyTag"                # Key Tag of EC2 that contains a Comma separated list of IAM groups to import - IAM_AUTHORIZED_GROUPS_TAG will override IAM_AUTHORIZED_GROUPS, you can use only one of them
 SUDOERS_GROUPS_TAG="KeyTag"                       # Key Tag of EC2 that contains a Comma separated list of IAM groups that should have sudo access - SUDOERS_GROUPS_TAG will override SUDOERS_GROUPS, you can use only one of them

--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ SUDOERS_GROUPS="GROUPNAMES"                       # Comma seperated list of IAM 
 IAM_AUTHORIZED_GROUPS_TAG="KeyTag"                # Key Tag of EC2 that contains a Comma separated list of IAM groups to import - IAM_AUTHORIZED_GROUPS_TAG will override IAM_AUTHORIZED_GROUPS, you can use only one of them
 SUDOERS_GROUPS_TAG="KeyTag"                       # Key Tag of EC2 that contains a Comma separated list of IAM groups that should have sudo access - SUDOERS_GROUPS_TAG will override SUDOERS_GROUPS, you can use only one of them
 SUDOERSGROUP="GROUPNAME"                          # Deprecated! IAM group that should have sudo access. Please use SUDOERS_GROUPS as this variable will be removed in future release.
-LOCAL_MARKER_GROUP="iam-synced-users"             # Dedicated UNIX group to mark imported users. Used for deleting removed IAM users
+LOCAL_MARKER_GROUP="iam-synced-users"             # Deprecated! Can only be defined during during installation for legacy transfer support.
+                                                  # Dedicated UNIX group previously used to track imported users
+                                                  # , enabling deletion of removed IAM users.
+                                                  # When found during installation, this group will be transfered to the state file
+                                                  # and deleted afterwards.
 LOCAL_GROUPS="GROUPNAMES"                         # Comma seperated list of UNIX groups to add the users in
 LOCAL_GROUP_MAP='{"local-group": ["iam-group"]}'  # JSON string indicating iam-groups to add to local-groups
 LOCAL_GROUP_MAP_TAG="KeyTag"                      # Key Tag of EC2 that contains a value for LOCAL_GROUP_MAP
@@ -118,9 +122,19 @@ USERADD_PROGRAM="/usr/sbin/useradd"               # The useradd program to use. 
 USERADD_ARGS="--create-home --shell /bin/bash"    # Arguments for the useradd program. defaults to `--create-home --shell /bin/bash`
 ```
 
-The LOCAL_MARKER_GROUP will be created if it does not exist. BEWARE: DO NOT add any manually created users
-to this group as they will be deleted in the next sync. This group is used by aws-ec2-ssh to keep track
-of what users were imported in the last run.
+## State
+The install script will create a state file `/etc/aws-ec2-ssh.conf`. This file will hold the current state of
+syncing at any moment and is automatically created.
+
+__WARNING__: Editing this file is at own risk and strongly discouraged, as it can have unexpected consequences.  
+For example: adding manually created users to STATE_SYNCED_USERS could result in those users
+being deleted in the next sync if they are not found as iam-users to be imported.
+
+This file will contain one or more of the following lines:
+```
+STATE_SYNCED_USERS="user list"      # Space separated list of users currently synced between iam and local system.
+                                    # This list replaces the deprecated LOCAL_MARKER_GROUP configuration
+```
 
 ## Using a multi account strategy with a central IAM user account
 

--- a/import_users.sh
+++ b/import_users.sh
@@ -205,8 +205,10 @@ function create_or_update_local_user() {
         SaveUserSudoFilePath="/etc/sudoers.d/$SaveUserFileName"
         if [[ "${SUDOERS_GROUPS}" == "##ALL##" ]] || in_list "${username}" "${sudousers}"
         then
-            echo "${username} ALL=(ALL) NOPASSWD:ALL" > "${SaveUserSudoFilePath}"
-            log "Granted sudo access for user '${username}'"
+            if [[ ! -f "${SaveUserSudoFilePath}" ]] ; then
+                echo "${username} ALL=(ALL) NOPASSWD:ALL" > "${SaveUserSudoFilePath}"
+                log "Granted sudo access for user '${username}'"
+            fi
         else
             if [[ -f "${SaveUserSudoFilePath}" ]] ; then
                 rm "${SaveUserSudoFilePath}"

--- a/import_users.sh
+++ b/import_users.sh
@@ -107,6 +107,19 @@ function get_ec2_tag_value() {
         --query "Tags[0].Value" --output text \
     )
 
+    if [ $? != 0 ] ; then
+        exitlog "Error retrieving EC2 tag value for '$1'."
+    fi
+
+    if [ "$tag_value" == "None" ] ; then
+        warn_msg="Warning: EC2 tag key '$1' not found."
+
+        echo "$warn_msg" >&2
+        log "$warn_msg"
+
+        tag_value=""
+    fi
+
     echo "$tag_value"
 }
 

--- a/import_users.sh
+++ b/import_users.sh
@@ -124,15 +124,17 @@ function get_ec2_tag_value() {
 }
 
 # Get list of IAM users (in IAM groups if defined as input argument)
-# Optional argument: comma-separated list of IAM groups to return IAM users for
+# input argument: comma-separated list of IAM groups to return IAM users for.
+#                 Define "##ALL##" as input value to retrieve all available IAM users
 function get_iam_users() {
-    local grouplist
-    if [ ! -z "$1" ]; then
-        grouplist=$1
+    local grouplist="$1"
+
+    if [ -z "$grouplist" ]
+    then
+        return 0
     fi
 
-    local group
-    if [ -z "$grouplist" ]
+    if [ "$grouplist" == "##ALL##" ]
     then
         aws iam list-users \
             --query "Users[].[UserName]" \
@@ -140,6 +142,7 @@ function get_iam_users() {
           | sed "s/\r//g" \
           || exitlog "Error while retrieving all IAM users."
     else
+        local group
         for group in $(echo ${grouplist} | tr "," " "); do
             aws iam get-group \
                 --group-name "${group}" \

--- a/import_users.sh
+++ b/import_users.sh
@@ -193,10 +193,7 @@ function create_or_update_local_user() {
         log "Created new user ${username}"
     fi
 
-    if [ ! -z $localusergroups ]
-    then
-        /usr/sbin/usermod -G "${localusergroups}" "${username}"
-    fi
+    /usr/sbin/usermod -G "${localusergroups}" "${username}"
 
     # Should we add this user to sudo ?
     if [[ ! -z "${SUDOERS_GROUPS}" ]]

--- a/import_users.sh
+++ b/import_users.sh
@@ -87,41 +87,41 @@ function setup_aws_credentials() {
 
 # Get EC2 tag value
 function get_ec2_tag_value() {
-	local tag_value=$(\
-		aws --region $REGION ec2 describe-tags \
-		--filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$1" \
-		--query "Tags[0].Value" --output text \
-	)
+    local tag_value=$(\
+        aws --region $REGION ec2 describe-tags \
+        --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$1" \
+        --query "Tags[0].Value" --output text \
+    )
 
-	echo "$tag_value"
+    echo "$tag_value"
 }
 
 # Get list of IAM users (in IAM groups if defined as input argument)
 # Optional argument: comma-separated list of IAM groups to return IAM users for
 function get_iam_users() {
-	local grouplist
-	if [ ! -z "$1" ]; then
-		grouplist=$1
-	fi
-	
-	local group
-	if [ -z "$grouplist" ]
-	then
-		aws iam list-users \
-		    --query "Users[].[UserName]" \
-		    --output text \
-		| sed "s/\r//g" \
-		|| exitlog "Error while retrieving all IAM users."
-	else
-		for group in $(echo ${grouplist} | tr "," " "); do
-			aws iam get-group \
-			    --group-name "${group}" \
-			    --query "Users[].[UserName]" \
-			    --output text \
-			| sed "s/\r//g" \
-			|| exitlog "Error while retrieving IAM users for group '${group}'"
-		done
-	fi
+    local grouplist
+    if [ ! -z "$1" ]; then
+        grouplist=$1
+    fi
+
+    local group
+    if [ -z "$grouplist" ]
+    then
+        aws iam list-users \
+            --query "Users[].[UserName]" \
+            --output text \
+          | sed "s/\r//g" \
+          || exitlog "Error while retrieving all IAM users."
+    else
+        for group in $(echo ${grouplist} | tr "," " "); do
+            aws iam get-group \
+                --group-name "${group}" \
+                --query "Users[].[UserName]" \
+                --output text \
+              | sed "s/\r//g" \
+              || exitlog "Error while retrieving IAM users for group '${group}'"
+        done
+    fi
 }
 
 # Get previously synced users

--- a/import_users.sh
+++ b/import_users.sh
@@ -180,7 +180,7 @@ function create_or_update_local_user() {
 
     if [ ! -z $localusergroups ]
     then
-        /usr/sbin/usermod -a -G "${localusergroups}" "${username}"
+        /usr/sbin/usermod -G "${localusergroups}" "${username}"
     fi
 
     # Should we add this user to sudo ?

--- a/import_users.sh
+++ b/import_users.sh
@@ -193,8 +193,12 @@ function create_or_update_local_user() {
         if [[ "${SUDOERS_GROUPS}" == "##ALL##" ]] || in_list "${username}" "${sudousers}"
         then
             echo "${username} ALL=(ALL) NOPASSWD:ALL" > "${SaveUserSudoFilePath}"
+            log "Granted sudo access for user '${username}'"
         else
-            [[ ! -f "${SaveUserSudoFilePath}" ]] || rm "${SaveUserSudoFilePath}"
+            if [[ -f "${SaveUserSudoFilePath}" ]] ; then
+                rm "${SaveUserSudoFilePath}"
+                log "Revoked sudo access for user '${username}'"
+            fi
         fi
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,7 @@ RELEASE="master"
 LOCAL_MARKER_GROUP="iam-synced-users"
 CLEAN_STATE="0"
 STATE_SYNCED_USERS=""
+STATE_MANAGED_GROUPS=""
 
 if [ $# == 0 ] ; then
 	echo "No input arguments provided. Please provide one or more input arguments."
@@ -282,6 +283,9 @@ fi
 #Write state file
 cat /dev/null > $MAIN_STATE_FILE
 echo "STATE_SYNCED_USERS=\"$STATE_SYNCED_USERS\"" >> $MAIN_STATE_FILE
+if [ ! -z $STATE_MANAGED_GROUPS ]; then
+    echo "STATE_MANAGED_GROUPS=\"$STATE_MANAGED_GROUPS\"" >> $MAIN_STATE_FILE
+fi
 
 ./install_configure_selinux.sh
 

--- a/install.sh
+++ b/install.sh
@@ -224,6 +224,7 @@ SHELL=/bin/bash
 PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/aws/bin
 MAILTO=root
 HOME=/
+@reboot      root $IMPORT_USERS_SCRIPT_FILE
 */10 * * * * root $IMPORT_USERS_SCRIPT_FILE
 EOF
 chmod 0644 /etc/cron.d/import_users

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,7 @@ fi
 
 cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
 cp import_users.sh $IMPORT_USERS_SCRIPT_FILE
+cat /dev/null > $MAIN_CONFIG_FILE
 
 if [ "${IAM_GROUPS}" != "" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ if [ $# == 0 ] ; then
 fi
 
 #Process input arguments with GNU getopt to support long args
-OPTS=`getopt -o hva:r: --l "assume:,import-groups:,import-groups-tag:,sudo-groups:,sudo-groups-tag:,local-groups:,local-group-map:,local-group-map-tag:,useradd-program:,useradd-args:,release:,help" \
+OPTS=`getopt -o hva:r: --l "assume:,import-groups:,import-groups-tag:,sudo-groups:,sudo-groups-tag:,local-groups:,local-group-map:,local-group-map-tag:,useradd-program:,useradd-args:,local-marker-group:,clean-state,release:,help" \
              -n 'install.sh' -- "$@"`
 
 if [ $? != 0 ] ; then
@@ -207,7 +207,7 @@ function get_localgroup_users() {
     bash -c "$get_group_members" -- "$1"
 }
 
-if [ $CLEAN_STATE != "0" ] && [ -f $MAIN_STATE_FILE ]
+if [ "$CLEAN_STATE" == "0" ] && [ -f $MAIN_STATE_FILE ]
 then
      . $MAIN_STATE_FILE
 fi

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,8 @@ Install import_users.sh and authorized_key_commands.
                                         This can be used if you define your users in one AWS account, while the EC2
                                         instance you use this script runs in another.
     --import-groups <group,group>       Import users from the IAM group(s) defined here (allow access to this instance).
-                                        Comma seperated list of IAM groups. Define an empty string for all available IAM users.
+                                        Comma seperated list of IAM groups. Provide the string '##ALL##' to import all
+                                        available IAM users.
     --import-groups-tag <tagKey>        Import users from the IAM group(s) defined here (allow access to this instance).
                                         Key of a tag found on EC2 instance with a value as defined for <import-groups>.
                                         One of import-groups or import-groups-tag must be defined.

--- a/install.sh
+++ b/install.sh
@@ -106,13 +106,29 @@ if ! [ -x "$(which git)" ]; then
     exit 1
 fi
 
-tmpdir=$(mktemp -d)
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-cd "$tmpdir"
+# check if install script is part of a local git clone or downloaded as standalone
+SOURCE_LOCATION=""
+if [ -f $SCRIPTPATH/aws-ec2-ssh.conf ] && [ -d $SCRIPTPATH/.git/ ]; then
+	SOURCE_LOCATION="local";
+else
+	SOURCE_LOCATION="github";
+fi
 
-git clone -b "$RELEASE" https://github.com/widdix/aws-ec2-ssh.git
+echo "Source location: $SOURCE_LOCATION"
 
-cd "$tmpdir/aws-ec2-ssh"
+if [ $SOURCE_LOCATION == "github" ]; then
+	tmpdir=$(mktemp -d)
+
+	cd "$tmpdir"
+
+	git clone -b "$RELEASE" https://github.com/widdix/aws-ec2-ssh.git
+	
+	cd "$tmpdir/aws-ec2-ssh"
+else
+	cd $SCRIPTPATH
+fi
 
 cp authorized_keys_command.sh $AUTHORIZED_KEYS_COMMAND_FILE
 cp import_users.sh $IMPORT_USERS_SCRIPT_FILE


### PR DESCRIPTION
Depending on (/including commits from) pull request #150 

In order to be able to do flexible group assign for select (IAM) users to one or more local groups (instead of assigning `LOCAL_GROUPS` to all imported users), I made several code changes. These are the highlights:
* Implemented option to assign select user(group)s to select local group(s) through the config options `LOCAL_GROUP_MAP` or `LOCAL_GROUP_MAP_TAG`, using a JSON data structure to map IAM user group(s) to local user group(s)
* Local group management by creating and removing groups that do not exist on first usage
* Moved sync status tracking (users and groups) to a state file rather than a user group (previously users were tracked using user group `iam-synced-users`) including options to upgrade to the new state file without losing current syncing state
* General code structure and error handling improvements