### PR TITLE
Add support for AWS IMDSv2

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -61,8 +61,9 @@ fi
 : ${USERDEL_ARGS:="--force --remove"}
 
 # Initizalize INSTANCE variable
-INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+METADATA_TOKEN=$(curl -s -XPUT -H 'x-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)
+INSTANCE_ID=$(curl -s -H "x-aws-ec2-metadata-token: ${METADATA_TOKEN}" http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s -H "x-aws-ec2-metadata-token: ${METADATA_TOKEN}" http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
 
 function setup_aws_credentials() {
     local stscredentials

--- a/import_users.sh
+++ b/import_users.sh
@@ -61,7 +61,7 @@ fi
 : ${USERDEL_ARGS:="--force --remove"}
 
 # Initizalize INSTANCE variable
-METADATA_TOKEN=$(curl -s -XPUT -H 'x-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)
+METADATA_TOKEN=$(curl -s -X PUT -H 'x-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)
 INSTANCE_ID=$(curl -s -H "x-aws-ec2-metadata-token: ${METADATA_TOKEN}" http://169.254.169.254/latest/meta-data/instance-id)
 REGION=$(curl -s -H "x-aws-ec2-metadata-token: ${METADATA_TOKEN}" http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
 


### PR DESCRIPTION
IMDSv2 is a measure to protect AWS EC2 instances against several types of security vulnerabilities. See the detailed description [here](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).

With this PR merged, it would be possible to enforce IMDSv2 (by disabling IMDSv1) and harden EC2 instances that use `aws-ec2-ssh` software.